### PR TITLE
#13 [Feat] Divider 공통 컴포넌트 구현

### DIFF
--- a/src/components/Divider/Divider.style.ts
+++ b/src/components/Divider/Divider.style.ts
@@ -1,0 +1,30 @@
+import { theme } from "@/styles/theme/theme";
+import { css } from "@emotion/react";
+
+export const wrapperStyle = (variant: "single" | "date") => css`
+  display: flex;
+
+  width: 100%;
+
+  align-items: center;
+  justify-content: center;
+
+  gap: ${variant === "date" ? "4.1rem" : "0"};
+`;
+
+export const dividerStyle = css`
+  width: 100%;
+  height: 0.1rem;
+
+  border: none;
+
+  background-color: #657791;
+`;
+
+export const childrenStyle = css`
+  white-space: nowrap;
+
+  ${theme.font.body3}
+
+  color: ${theme.color.gray1}
+`;

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -14,7 +14,7 @@ const Divider = ({ variant = "single", children }: DividerProps) => {
   return (
     <div css={wrapperStyle(variant)}>
       <hr css={dividerStyle} />
-      <p css={childrenStyle}>{children}</p>
+      {variant === "date" && <p css={childrenStyle}>{children}</p>}
       <hr css={dividerStyle} />
     </div>
   );

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -6,9 +6,9 @@ interface DividerProps extends HTMLAttributes<HTMLHRElement> {
   variant?: "single" | "date";
 }
 
-const Divider = ({ variant = "single", children }: DividerProps) => {
+const Divider = ({ variant = "single", children, ...props }: DividerProps) => {
   return (
-    <div css={s.wrapperStyle(variant)}>
+    <div css={s.wrapperStyle(variant)} {...props}>
       <hr css={s.dividerStyle} />
       {variant === "date" && <p css={s.childrenStyle}>{children}</p>}
       <hr css={s.dividerStyle} />

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,0 +1,23 @@
+import {
+  childrenStyle,
+  dividerStyle,
+  wrapperStyle,
+} from "@/components/Divider/Divider.style";
+
+import type { HTMLAttributes } from "react";
+
+interface DividerProps extends HTMLAttributes<HTMLHRElement> {
+  variant?: "single" | "date";
+}
+
+const Divider = ({ variant = "single", children }: DividerProps) => {
+  return (
+    <div css={wrapperStyle(variant)}>
+      <hr css={dividerStyle} />
+      <p css={childrenStyle}>{children}</p>
+      <hr css={dividerStyle} />
+    </div>
+  );
+};
+
+export default Divider;

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,8 +1,4 @@
-import {
-  childrenStyle,
-  dividerStyle,
-  wrapperStyle,
-} from "@/components/Divider/Divider.style";
+import * as s from "@/components/Divider/Divider.style";
 
 import type { HTMLAttributes } from "react";
 
@@ -12,10 +8,10 @@ interface DividerProps extends HTMLAttributes<HTMLHRElement> {
 
 const Divider = ({ variant = "single", children }: DividerProps) => {
   return (
-    <div css={wrapperStyle(variant)}>
-      <hr css={dividerStyle} />
-      {variant === "date" && <p css={childrenStyle}>{children}</p>}
-      <hr css={dividerStyle} />
+    <div css={s.wrapperStyle(variant)}>
+      <hr css={s.dividerStyle} />
+      {variant === "date" && <p css={s.childrenStyle}>{children}</p>}
+      <hr css={s.dividerStyle} />
     </div>
   );
 };


### PR DESCRIPTION
## 🎯 관련 이슈

close #13 

<br />

## 🚀 작업 내용

- 공통 Divider를 구현했습니다.

세로선은 현재 ui에 쓰이지 않아서 `가로 divider`만 고려해서 구현했습니다.

### variant
1. single
2. date

`single`의 경우 일반 선이고 `date`의 경우 중앙에 날짜가 적혀져 있는 divider입니다.
더 좋은 네이밍이 있다면 추천해주세용 

div 사이에 hr을 배치하고 variant에 따라 gap의 값을 달리 주는 방식으로 구현했습니다.
현재 색상이 전체적으로 바뀔 것 같기도 하고 theme에 없는 색상이라 하드코딩으로 지정해놨습니다.

<br />


## 📸 스크린샷

1. single

<img width="622" alt="스크린샷 2025-01-22 오후 3 58 59" src="https://github.com/user-attachments/assets/8a19cba6-e6bf-4b9c-860b-7573ce7fc569" />

2. date

<img width="622" alt="스크린샷 2025-01-22 오후 3 58 34" src="https://github.com/user-attachments/assets/7549bb9a-1a88-40f6-bcf9-06e61c6541c8" />


<br />


<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
