### PR TITLE
#24 [FEAT] 회원가입 validation 및 데이터 관리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
 import { MenuHeader, ServerHeader } from "@/components";
+import { css } from "@emotion/react";
 import { Outlet } from "react-router-dom";
 
 const App = () => {
   return (
-    <div css={{ display: "flex" }}>
+    <div css={layoutStyle}>
       <ServerHeader />
       <MenuHeader />
       <Outlet />
@@ -12,3 +13,7 @@ const App = () => {
 };
 
 export default App;
+
+const layoutStyle = css`
+  display: flex;
+`;

--- a/src/components/AuthContainer/AuthContainer.styles.ts
+++ b/src/components/AuthContainer/AuthContainer.styles.ts
@@ -19,12 +19,12 @@ export const sectionStyle = (size: "medium" | "large") => css`
   display: flex;
 
   width: 81rem;
-  height: ${size === "large" ? "58.7rem" : "43rem"};
+  height: ${size === "large" ? "58.7rem" : "44rem"};
 
   padding: 5rem 7.8rem 5rem 6rem;
 
   justify-content: space-between;
-  gap: 5rem;
+  gap: 16rem;
 
   border-radius: 2.5rem;
 
@@ -63,19 +63,21 @@ export const descStyle = css`
 export const childrenStyle = (size: "medium" | "large") => css`
   display: flex;
 
+  padding-top: ${size === "large" ? "3rem" : "7.1rem"};
+
   flex-direction: column;
   flex-grow: 1;
-  gap: 1.8rem;
-
   align-items: flex-end;
 
-  padding-top: ${size === "large" ? "3rem" : "7.1rem"};
+  gap: 2rem;
 `;
 
 export const sideStyle = css`
   display: flex;
 
+  width: 16rem;
+
   flex-direction: column;
-  flex-grow: 1;
+
   gap: 2.1rem;
 `;

--- a/src/components/AuthContainer/AuthContainer.styles.ts
+++ b/src/components/AuthContainer/AuthContainer.styles.ts
@@ -24,7 +24,7 @@ export const sectionStyle = (size: "medium" | "large") => css`
   padding: 5rem 7.8rem 5rem 6rem;
 
   justify-content: space-between;
-  gap: 16rem;
+  gap: ${size === "large" ? "5.5rem" : "16rem"};
 
   border-radius: 2.5rem;
 

--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -26,6 +26,9 @@ export const buttonStyle = css`
   &:hover {
     scale: 1.02;
   }
+
+  &:disabled {
+  }
 `;
 
 const textBaseStyle = css`

--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -60,6 +60,14 @@ export const variantStyles: Record<
     }
   `,
 
+  tertiary: css`
+    background-color: ${theme.color.dark2};
+
+    &:hover {
+      background-color: ${theme.color.dark1};
+    }
+  `,
+
   text: css`
     ${textBaseStyle};
     text-decoration: underline;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,7 +3,7 @@ import type { ButtonHTMLAttributes } from "react";
 import { buttonStyle, variantStyles } from "./Button.style";
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: "primary" | "secondary" | "text" | "sorting";
+  variant?: "primary" | "secondary" | "tertiary" | "text" | "sorting";
 }
 
 const Button = ({ variant = "primary", children, ...props }: ButtonProps) => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,11 +8,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const Button = ({ variant = "primary", children, ...props }: ButtonProps) => {
   return (
-    <button
-      type="button"
-      css={[buttonStyle, variantStyles[variant]]}
-      {...props}
-    >
+    <button type="button" css={[buttonStyle, variantStyles[variant]]} {...props}>
       {children}
     </button>
   );

--- a/src/components/CheckBox/Checkbox.tsx
+++ b/src/components/CheckBox/Checkbox.tsx
@@ -8,7 +8,15 @@ interface CheckBoxProps extends HTMLAttributes<HTMLInputElement> {
 const CheckBox = ({ id, isChecked, onChange, ...props }: CheckBoxProps) => {
   return (
     <div css={s.boxWrapperStyle}>
-      <input type="checkbox" id={id} css={s.checkboxStyle} onChange={onChange} aria-checked={isChecked} {...props} />
+      <input
+        type="checkbox"
+        id={id}
+        css={s.checkboxStyle}
+        onChange={onChange}
+        checked={isChecked}
+        aria-checked={isChecked}
+        {...props}
+      />
     </div>
   );
 };

--- a/src/components/Input/Input.styles.ts
+++ b/src/components/Input/Input.styles.ts
@@ -1,6 +1,14 @@
 import { theme } from "@/styles/theme/theme";
 import { css } from "@emotion/react";
 
+export const layoutStyle = (supportingText: boolean) => css`
+  position: relative;
+
+  width: 100%;
+
+  margin-bottom: ${supportingText ? "1.5rem" : "0"};
+`;
+
 export const wrapperStyle = (
   hasLeftIcon: boolean,
   hasRightIcon: boolean,

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,4 +1,5 @@
 import * as s from "@/components/Input/Input.styles";
+import SupportingText from "@/components/SupportingText/SupportingText";
 import {
   type ForwardedRef,
   type InputHTMLAttributes,
@@ -10,6 +11,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   isError?: boolean;
   leftIcon?: ReactNode;
   rightIcon?: ReactNode;
+  supportingText?: string;
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
@@ -21,24 +23,29 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       placeholder,
       id,
       value,
-      maxLength,
+      supportingText,
       ...props
     }: InputProps,
     ref: ForwardedRef<HTMLInputElement>
   ) => {
     return (
-      <div css={s.wrapperStyle(!!leftIcon, !!rightIcon, isError)}>
-        {leftIcon}
-        <input
-          css={s.inputStyle}
-          placeholder={placeholder}
-          id={id}
-          ref={ref}
-          value={value}
-          tabIndex={0}
-          {...props}
-        />
-        <div css={{ cursor: "pointer" }}>{rightIcon}</div>
+      <div css={s.layoutStyle(!!supportingText && isError)}>
+        <div css={s.wrapperStyle(!!leftIcon, !!rightIcon, isError)}>
+          {leftIcon}
+          <input
+            css={s.inputStyle}
+            placeholder={placeholder}
+            id={id}
+            ref={ref}
+            value={value}
+            tabIndex={0}
+            {...props}
+          />
+          <div css={{ cursor: "pointer" }}>{rightIcon}</div>
+        </div>
+        {isError && supportingText && (
+          <SupportingText>{supportingText}</SupportingText>
+        )}
       </div>
     );
   }

--- a/src/components/SupportingText/SupportingText.style.ts
+++ b/src/components/SupportingText/SupportingText.style.ts
@@ -1,0 +1,17 @@
+import { theme } from "@/styles/theme/theme";
+import { css } from "@emotion/react";
+
+export const supportingTextStyle = css`
+  position: absolute;
+  display: flex;
+
+  width: 100%;
+
+  justify-content: flex-end;
+
+  padding-top: 0.8rem;
+
+  color: ${theme.color.primaryPink1};
+
+  ${theme.font.body2};
+`;

--- a/src/components/SupportingText/SupportingText.tsx
+++ b/src/components/SupportingText/SupportingText.tsx
@@ -1,0 +1,14 @@
+import * as s from "@/components/SupportingText/SupportingText.style";
+import type { ComponentPropsWithRef } from "react";
+
+type SupportingTextType = ComponentPropsWithRef<"p">;
+
+const SupportingText = ({ children, ...props }: SupportingTextType) => {
+  return (
+    <p css={s.supportingTextStyle} {...props}>
+      {children}
+    </p>
+  );
+};
+
+export default SupportingText;

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -5,7 +5,6 @@ import {
   type ForwardedRef,
   type TextareaHTMLAttributes,
   forwardRef,
-  useState,
 } from "react";
 
 interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -20,20 +19,11 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       id,
       value = "",
       maxLength,
+      onChange,
       ...props
     }: TextareaProps,
     ref: ForwardedRef<HTMLTextAreaElement>
   ) => {
-    const [text, setText] = useState(value.toString());
-    const [count, setCount] = useState(text.length);
-
-    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      setText(e.target.value);
-      setCount(e.target.value.length);
-
-      props.onChange?.(e);
-    };
-
     return (
       <div css={s.wrapperStyle(isError)}>
         <textarea
@@ -42,15 +32,17 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           id={id}
           ref={ref}
           maxLength={maxLength}
-          value={text}
-          onChange={handleChange}
+          value={value}
+          onChange={onChange}
           tabIndex={0}
           {...props}
         />
         {maxLength && (
           <div css={s.countStyle}>
-            <p css={{ color: `${theme.color.primaryBlue2}` }}>{count}</p> /
-            {maxLength}
+            <p css={{ color: `${theme.color.primaryBlue2}` }}>
+              {value.toString().length}
+            </p>
+            / {maxLength}
           </div>
         )}
       </div>

--- a/src/pages/SignupPage/components/ContactStep/ContactStep.tsx
+++ b/src/pages/SignupPage/components/ContactStep/ContactStep.tsx
@@ -2,8 +2,9 @@ import { PlusIcon } from "@/assets/svg";
 import { AuthContainer, Button, Input } from "@/components";
 import { PLACEHOLDER } from "@/constants/placeholder";
 import { DESC, TITLE } from "@/constants/signup";
+
 import * as s from "@/pages/SignupPage/components/ContactStep/ContactStep.styles";
-import { useState } from "react";
+import { useUrlForm } from "@/pages/SignupPage/hooks/useUrlForm";
 
 interface ContactStepProps {
   onPrev: () => void;
@@ -11,37 +12,45 @@ interface ContactStepProps {
 }
 
 const ContactStep = ({ onPrev, onNext }: ContactStepProps) => {
-  const [urls, setUrls] = useState<string[]>([""]);
+  const { urls, handleAddInput, handleChange } = useUrlForm();
 
-  const handleAddInput = () => {
-    setUrls([...urls, ""]);
-  };
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
 
-  const handleChange = (index: number, value: string) => {
-    setUrls((prev) => prev.map((url, i) => (i === index ? value : url)));
+    const prev = JSON.parse(sessionStorage.getItem("signup") || "{}");
+    sessionStorage.setItem("signup", JSON.stringify({ ...prev, urls }));
+
+    onNext();
   };
 
   return (
-    <AuthContainer title={TITLE.PROFILE} desc={DESC.BASIC_INFO}>
-      <div css={s.urlLayoutStyle}>
-        {urls.map((url, index) => (
-          <Input
-            // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
-            key={index}
-            placeholder={PLACEHOLDER.URL}
-            value={url}
-            onChange={(e) => handleChange(index, e.target.value)}
-          />
-        ))}
-      </div>
-      <PlusIcon width={16} height={16} css={{ cursor: "pointer", flexShrink: "0" }} onClick={handleAddInput} />
-      <div css={s.btnLayoutStyle}>
-        <Button variant="secondary" onClick={onPrev}>
-          이전
-        </Button>
-        <Button onClick={onNext}>다음</Button>
-      </div>
-    </AuthContainer>
+    <form onSubmit={handleSubmit} css={{ zIndex: 1 }}>
+      <AuthContainer title={TITLE.PROFILE} desc={DESC.BASIC_INFO}>
+        <div css={s.urlLayoutStyle}>
+          {urls?.map((url, index) => (
+            <Input
+              // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+              key={index}
+              placeholder={PLACEHOLDER.URL}
+              value={url}
+              onChange={(e) => handleChange(index, e.target.value)}
+            />
+          ))}
+        </div>
+        <PlusIcon
+          width={16}
+          height={16}
+          css={{ cursor: "pointer", flexShrink: "0" }}
+          onClick={handleAddInput}
+        />
+        <div css={s.btnLayoutStyle}>
+          <Button variant="tertiary" onClick={onPrev}>
+            이전
+          </Button>
+          <Button type="submit">다음</Button>
+        </div>
+      </AuthContainer>
+    </form>
   );
 };
 

--- a/src/pages/SignupPage/components/ContactStep/ContactStep.tsx
+++ b/src/pages/SignupPage/components/ContactStep/ContactStep.tsx
@@ -17,9 +17,6 @@ const ContactStep = ({ onPrev, onNext }: ContactStepProps) => {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    const prev = JSON.parse(sessionStorage.getItem("signup") || "{}");
-    sessionStorage.setItem("signup", JSON.stringify({ ...prev, urls }));
-
     onNext();
   };
 
@@ -37,12 +34,7 @@ const ContactStep = ({ onPrev, onNext }: ContactStepProps) => {
             />
           ))}
         </div>
-        <PlusIcon
-          width={16}
-          height={16}
-          css={{ cursor: "pointer", flexShrink: "0" }}
-          onClick={handleAddInput}
-        />
+        <PlusIcon width={16} height={16} css={{ cursor: "pointer", flexShrink: "0" }} onClick={handleAddInput} />
         <div css={s.btnLayoutStyle}>
           <Button variant="tertiary" onClick={onPrev}>
             이전

--- a/src/pages/SignupPage/components/InfoStep/InfoStep.tsx
+++ b/src/pages/SignupPage/components/InfoStep/InfoStep.tsx
@@ -10,40 +10,35 @@ interface InfoStepProps {
 }
 
 const InfoStep = ({ onNext }: InfoStepProps) => {
-  const { handleInfoChange, info, isNickNameError, isBirthError } = useInfoForm();
+  const { handleInfoChange, form, isNickNameError, isBirthError } =
+    useInfoForm();
 
-  const isButtonDisabled = !info.name || isNickNameError || isBirthError;
+  const isButtonDisabled = !form.name || isNickNameError || isBirthError;
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
-    sessionStorage.setItem(
-      "signup",
-      JSON.stringify({
-        name: info.name,
-        nickName: info.nickName,
-        birth: formatDate(info.birth),
-      }),
-    );
-
     onNext();
   };
 
   return (
     <form onSubmit={handleSubmit} css={{ zIndex: 1 }}>
       <AuthContainer title={TITLE.PROFILE} desc={DESC.BASIC_INFO}>
-        <Input placeholder={PLACEHOLDER.NAME} onChange={(e) => handleInfoChange(e, "name")} value={info.name} />
+        <Input
+          placeholder={PLACEHOLDER.NAME}
+          onChange={(e) => handleInfoChange(e, "name")}
+          value={form.name}
+        />
         <Input
           placeholder={PLACEHOLDER.NICKNAME}
           onChange={(e) => handleInfoChange(e, "nickName")}
-          value={info.nickName}
+          value={form.nickName}
           isError={isNickNameError}
           supportingText={SUPPORTING_TEXT.NICKNAME}
         />
         <Input
           placeholder={PLACEHOLDER.BIRTH}
           onChange={(e) => handleInfoChange(e, "birth")}
-          value={formatDate(info.birth)}
+          value={formatDate(form.birth)}
           isError={isBirthError}
           supportingText={SUPPORTING_TEXT.BIRTH}
         />

--- a/src/pages/SignupPage/components/InfoStep/InfoStep.tsx
+++ b/src/pages/SignupPage/components/InfoStep/InfoStep.tsx
@@ -15,32 +15,49 @@ const InfoStep = ({ onNext }: InfoStepProps) => {
 
   const isButtonDisabled = !info.name || isNickNameError || isBirthError;
 
-  return (
-    <AuthContainer title={TITLE.PROFILE} desc={DESC.BASIC_INFO}>
-      <Input
-        placeholder={PLACEHOLDER.NAME}
-        onChange={(e) => handleInfoChange(e, "name")}
-        value={info.name}
-      />
-      <Input
-        placeholder={PLACEHOLDER.NICKNAME}
-        onChange={(e) => handleInfoChange(e, "nickName")}
-        value={info.nickName}
-        isError={isNickNameError}
-        supportingText={SUPPORTING_TEXT.NICKNAME}
-      />
-      <Input
-        placeholder={PLACEHOLDER.BIRTH}
-        onChange={(e) => handleInfoChange(e, "birth")}
-        value={formatDate(info.birth)}
-        isError={isBirthError}
-        supportingText={SUPPORTING_TEXT.BIRTH}
-      />
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
 
-      <Button onClick={onNext} disabled={isButtonDisabled}>
-        다음
-      </Button>
-    </AuthContainer>
+    sessionStorage.setItem(
+      "signup",
+      JSON.stringify({
+        name: info.name,
+        nickName: info.nickName,
+        birth: formatDate(info.birth),
+      })
+    );
+
+    onNext();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} css={{ zIndex: 1 }}>
+      <AuthContainer title={TITLE.PROFILE} desc={DESC.BASIC_INFO}>
+        <Input
+          placeholder={PLACEHOLDER.NAME}
+          onChange={(e) => handleInfoChange(e, "name")}
+          value={info.name}
+        />
+        <Input
+          placeholder={PLACEHOLDER.NICKNAME}
+          onChange={(e) => handleInfoChange(e, "nickName")}
+          value={info.nickName}
+          isError={isNickNameError}
+          supportingText={SUPPORTING_TEXT.NICKNAME}
+        />
+        <Input
+          placeholder={PLACEHOLDER.BIRTH}
+          onChange={(e) => handleInfoChange(e, "birth")}
+          value={formatDate(info.birth)}
+          isError={isBirthError}
+          supportingText={SUPPORTING_TEXT.BIRTH}
+        />
+
+        <Button type="submit" disabled={isButtonDisabled}>
+          다음
+        </Button>
+      </AuthContainer>
+    </form>
   );
 };
 

--- a/src/pages/SignupPage/components/InfoStep/InfoStep.tsx
+++ b/src/pages/SignupPage/components/InfoStep/InfoStep.tsx
@@ -10,8 +10,7 @@ interface InfoStepProps {
 }
 
 const InfoStep = ({ onNext }: InfoStepProps) => {
-  const { handleInfoChange, info, isNickNameError, isBirthError } =
-    useInfoForm();
+  const { handleInfoChange, info, isNickNameError, isBirthError } = useInfoForm();
 
   const isButtonDisabled = !info.name || isNickNameError || isBirthError;
 
@@ -24,7 +23,7 @@ const InfoStep = ({ onNext }: InfoStepProps) => {
         name: info.name,
         nickName: info.nickName,
         birth: formatDate(info.birth),
-      })
+      }),
     );
 
     onNext();
@@ -33,11 +32,7 @@ const InfoStep = ({ onNext }: InfoStepProps) => {
   return (
     <form onSubmit={handleSubmit} css={{ zIndex: 1 }}>
       <AuthContainer title={TITLE.PROFILE} desc={DESC.BASIC_INFO}>
-        <Input
-          placeholder={PLACEHOLDER.NAME}
-          onChange={(e) => handleInfoChange(e, "name")}
-          value={info.name}
-        />
+        <Input placeholder={PLACEHOLDER.NAME} onChange={(e) => handleInfoChange(e, "name")} value={info.name} />
         <Input
           placeholder={PLACEHOLDER.NICKNAME}
           onChange={(e) => handleInfoChange(e, "nickName")}

--- a/src/pages/SignupPage/components/InfoStep/InfoStep.tsx
+++ b/src/pages/SignupPage/components/InfoStep/InfoStep.tsx
@@ -1,18 +1,45 @@
 import { AuthContainer, Button, Input } from "@/components";
 import { PLACEHOLDER } from "@/constants/placeholder";
 import { DESC, TITLE } from "@/constants/signup";
+import { SUPPORTING_TEXT } from "@/pages/SignupPage/constants/supportingText";
+import { useInfoForm } from "@/pages/SignupPage/hooks/useInfoForm";
+import { formatDate } from "@/pages/SignupPage/utils/date";
 
 interface InfoStepProps {
   onNext: () => void;
 }
 
 const InfoStep = ({ onNext }: InfoStepProps) => {
+  const { handleInfoChange, info, isNickNameError, isBirthError } =
+    useInfoForm();
+
+  const isButtonDisabled = !info.name || isNickNameError || isBirthError;
+
   return (
     <AuthContainer title={TITLE.PROFILE} desc={DESC.BASIC_INFO}>
-      <Input placeholder={PLACEHOLDER.NAME} />
-      <Input placeholder={PLACEHOLDER.NICKNAME} />
-      <Input placeholder={PLACEHOLDER.BIRTH} />
-      <Button onClick={onNext}>다음</Button>
+      <Input
+        placeholder={PLACEHOLDER.NAME}
+        onChange={(e) => handleInfoChange(e, "name")}
+        value={info.name}
+      />
+      <Input
+        placeholder={PLACEHOLDER.NICKNAME}
+        onChange={(e) => handleInfoChange(e, "nickName")}
+        value={info.nickName}
+        isError={isNickNameError}
+        supportingText={SUPPORTING_TEXT.NICKNAME}
+      />
+      <Input
+        placeholder={PLACEHOLDER.BIRTH}
+        onChange={(e) => handleInfoChange(e, "birth")}
+        value={formatDate(info.birth)}
+        isError={isBirthError}
+        supportingText={SUPPORTING_TEXT.BIRTH}
+      />
+
+      <Button onClick={onNext} disabled={isButtonDisabled}>
+        다음
+      </Button>
     </AuthContainer>
   );
 };

--- a/src/pages/SignupPage/components/InterestStep/InterestStep.tsx
+++ b/src/pages/SignupPage/components/InterestStep/InterestStep.tsx
@@ -1,7 +1,7 @@
 import { AuthContainer, Button, CheckBox } from "@/components";
 import { DESC, INTERESTS, TITLE } from "@/constants/signup";
 import * as s from "@/pages/SignupPage/components/InterestStep/InterestStep.styles";
-import { useState } from "react";
+import { useInterestSelection } from "@/pages/SignupPage/hooks/useInterestSelection";
 
 interface InterestStepProps {
   onPrev: () => void;
@@ -9,45 +9,57 @@ interface InterestStepProps {
 }
 
 const InterestStep = ({ onPrev, onNext }: InterestStepProps) => {
-  const [selectedInterests, setSelectedInterests] = useState<string[]>([]);
+  const { interests, handleCheckboxChange, handleReset } =
+    useInterestSelection();
 
-  const handleCheckboxChange = (interest: string) => {
-    setSelectedInterests((prev) =>
-      prev.includes(interest)
-        ? prev.filter((item) => item !== interest)
-        : [...prev, interest]
-    );
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const prev = JSON.parse(sessionStorage.getItem("signup") || "{}");
+    sessionStorage.setItem("signup", JSON.stringify({ ...prev, interests }));
+
+    onNext();
   };
 
   return (
-    <AuthContainer title={TITLE.PROFILE} desc={DESC.INTEREST_INFO} size="large">
-      <Button variant="text" css={{ textDecoration: "none" }}>
-        초기화
-      </Button>
-      <div css={s.boxWrapperStyle}>
-        {INTERESTS.map((field) => (
-          <label key={field} htmlFor={field} css={s.boxLayoutStyle}>
-            <CheckBox
-              id={field}
-              isChecked={selectedInterests.includes(field)}
-              onChange={() => handleCheckboxChange(field)}
-            />
-            <span css={s.labelStyle}>{field}</span>
-          </label>
-        ))}
-      </div>
-      <div css={{ display: "flex", gap: "2.6rem" }}>
-        <Button onClick={onPrev} variant="secondary">
-          이전
+    <form onSubmit={handleSubmit} css={{ zIndex: 1 }}>
+      <AuthContainer
+        title={TITLE.PROFILE}
+        desc={DESC.INTEREST_INFO}
+        size="large"
+      >
+        <Button
+          variant="text"
+          css={{ textDecoration: "none" }}
+          onClick={handleReset}
+        >
+          초기화
         </Button>
-        <Button variant="secondary" onClick={onNext}>
-          선택 안 함
-        </Button>
-        <Button onClick={onNext} disabled={selectedInterests.length === 0}>
-          다음
-        </Button>
-      </div>
-    </AuthContainer>
+        <div css={s.boxWrapperStyle}>
+          {INTERESTS.map((field) => (
+            <label key={field} htmlFor={field} css={s.boxLayoutStyle}>
+              <CheckBox
+                id={field}
+                isChecked={interests.includes(field)}
+                onChange={() => handleCheckboxChange(field)}
+              />
+              <span css={s.labelStyle}>{field}</span>
+            </label>
+          ))}
+        </div>
+        <div css={{ display: "flex", gap: "2.6rem" }}>
+          <Button onClick={onPrev} variant="tertiary">
+            이전
+          </Button>
+          <Button variant="secondary" onClick={onNext}>
+            선택 안 함
+          </Button>
+          <Button type="submit" disabled={interests.length === 0}>
+            다음
+          </Button>
+        </div>
+      </AuthContainer>
+    </form>
   );
 };
 

--- a/src/pages/SignupPage/components/InterestStep/InterestStep.tsx
+++ b/src/pages/SignupPage/components/InterestStep/InterestStep.tsx
@@ -14,9 +14,6 @@ const InterestStep = ({ onPrev, onNext }: InterestStepProps) => {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    const prev = JSON.parse(sessionStorage.getItem("signup") || "{}");
-    sessionStorage.setItem("signup", JSON.stringify({ ...prev, interests }));
-
     onNext();
   };
 

--- a/src/pages/SignupPage/components/InterestStep/InterestStep.tsx
+++ b/src/pages/SignupPage/components/InterestStep/InterestStep.tsx
@@ -9,8 +9,7 @@ interface InterestStepProps {
 }
 
 const InterestStep = ({ onPrev, onNext }: InterestStepProps) => {
-  const { interests, handleCheckboxChange, handleReset } =
-    useInterestSelection();
+  const { interests, handleCheckboxChange, handleReset } = useInterestSelection();
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -23,26 +22,14 @@ const InterestStep = ({ onPrev, onNext }: InterestStepProps) => {
 
   return (
     <form onSubmit={handleSubmit} css={{ zIndex: 1 }}>
-      <AuthContainer
-        title={TITLE.PROFILE}
-        desc={DESC.INTEREST_INFO}
-        size="large"
-      >
-        <Button
-          variant="text"
-          css={{ textDecoration: "none" }}
-          onClick={handleReset}
-        >
+      <AuthContainer title={TITLE.PROFILE} desc={DESC.INTEREST_INFO} size="large">
+        <Button variant="text" css={{ textDecoration: "none" }} onClick={handleReset}>
           초기화
         </Button>
         <div css={s.boxWrapperStyle}>
           {INTERESTS.map((field) => (
             <label key={field} htmlFor={field} css={s.boxLayoutStyle}>
-              <CheckBox
-                id={field}
-                isChecked={interests.includes(field)}
-                onChange={() => handleCheckboxChange(field)}
-              />
+              <CheckBox id={field} isChecked={interests.includes(field)} onChange={() => handleCheckboxChange(field)} />
               <span css={s.labelStyle}>{field}</span>
             </label>
           ))}
@@ -55,7 +42,7 @@ const InterestStep = ({ onPrev, onNext }: InterestStepProps) => {
             선택 안 함
           </Button>
           <Button type="submit" disabled={interests.length === 0}>
-            다음
+            완료
           </Button>
         </div>
       </AuthContainer>

--- a/src/pages/SignupPage/components/ProfileStep/ProfileStep.tsx
+++ b/src/pages/SignupPage/components/ProfileStep/ProfileStep.tsx
@@ -14,16 +14,6 @@ const ProfileStep = ({ onPrev, onNext }: ProfileStepProps) => {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    const prev = JSON.parse(sessionStorage.getItem("signup") || "{}");
-
-    const data = {
-      ...prev,
-      belonging: form.belonging,
-      introduction: form.introduction,
-    };
-
-    sessionStorage.setItem("signup", JSON.stringify(data));
-
     onNext();
   };
 

--- a/src/pages/SignupPage/components/ProfileStep/ProfileStep.tsx
+++ b/src/pages/SignupPage/components/ProfileStep/ProfileStep.tsx
@@ -1,6 +1,7 @@
 import { AuthContainer, Button, Input, Textarea } from "@/components";
 import { PLACEHOLDER } from "@/constants/placeholder";
 import { DESC, TITLE } from "@/constants/signup";
+import { useProfileForm } from "@/pages/SignupPage/hooks/useProfileForm";
 
 interface ProfileStepProps {
   onPrev: () => void;
@@ -8,17 +9,47 @@ interface ProfileStepProps {
 }
 
 const ProfileStep = ({ onPrev, onNext }: ProfileStepProps) => {
+  const { form, handleFormChange } = useProfileForm();
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const prev = JSON.parse(sessionStorage.getItem("signup") || "{}");
+
+    const data = {
+      ...prev,
+      belonging: form.belonging,
+      introduction: form.introduction,
+    };
+
+    sessionStorage.setItem("signup", JSON.stringify(data));
+
+    onNext();
+  };
+
   return (
-    <AuthContainer title={TITLE.PROFILE} desc={DESC.BASIC_INFO}>
-      <Input placeholder={PLACEHOLDER.BELONGING} />
-      <Textarea placeholder={PLACEHOLDER.INTRODUCTION} maxLength={80} css={{ height: "10rem" }} />
-      <div css={{ display: "flex", gap: "2rem" }}>
-        <Button variant="secondary" onClick={onPrev}>
-          이전
-        </Button>
-        <Button onClick={onNext}>다음</Button>
-      </div>
-    </AuthContainer>
+    <form onSubmit={handleSubmit} css={{ zIndex: 1 }}>
+      <AuthContainer title={TITLE.PROFILE} desc={DESC.BASIC_INFO}>
+        <Input
+          placeholder={PLACEHOLDER.BELONGING}
+          value={form.belonging}
+          onChange={(e) => handleFormChange(e, "belonging")}
+        />
+        <Textarea
+          placeholder={PLACEHOLDER.INTRODUCTION}
+          maxLength={80}
+          value={form.introduction}
+          onChange={(e) => handleFormChange(e, "introduction")}
+          css={{ height: "10rem" }}
+        />
+        <div css={{ display: "flex", gap: "2rem" }}>
+          <Button variant="tertiary" onClick={onPrev}>
+            이전
+          </Button>
+          <Button type="submit">다음</Button>
+        </div>
+      </AuthContainer>
+    </form>
   );
 };
 

--- a/src/pages/SignupPage/constants/supportingText.ts
+++ b/src/pages/SignupPage/constants/supportingText.ts
@@ -1,0 +1,4 @@
+export const SUPPORTING_TEXT = {
+  NICKNAME: "2~10자 이내로 입력해주세요",
+  BIRTH: "입력 형식을 확인해주세요 (YYYY.MM.DD)",
+};

--- a/src/pages/SignupPage/hooks/useInfoForm.ts
+++ b/src/pages/SignupPage/hooks/useInfoForm.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { SUPPORTING_TEXT } from "@/pages/SignupPage/constants/supportingText";
+
+type InfoFormKeys = "name" | "nickName" | "birth";
+
+export const useInfoForm = () => {
+  const [info, setInfo] = useState({
+    name: "",
+    nickName: "",
+    birth: "",
+  });
+
+  const [nickNameSupportingText, setNickNameSupportingText] = useState("");
+  const [birthSupportingText, setBirthSupportingText] = useState("");
+
+  const handleInfoChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>, key: InfoFormKeys) => {
+      const { value } = e.target;
+
+      setInfo((prev) => ({
+        ...prev,
+        [key]: value,
+      }));
+    },
+    []
+  );
+
+  const handleNickNameMessage = useCallback((nickName: string) => {
+    if (nickName.length < 2 || nickName.length > 10) {
+      setNickNameSupportingText(SUPPORTING_TEXT.NICKNAME);
+
+      return SUPPORTING_TEXT.NICKNAME;
+    }
+  }, []);
+
+  const handleBirthMessage = useCallback((birth: string) => {
+    if (birth.length !== 8) {
+      setBirthSupportingText(SUPPORTING_TEXT.BIRTH);
+
+      return SUPPORTING_TEXT.BIRTH;
+    }
+  }, []);
+
+  const isNickNameError =
+    info.nickName.length > 0 &&
+    (info.nickName.length < 2 || info.nickName.length > 10);
+  const isBirthError = info.birth.length > 0 && info.birth.length !== 8;
+
+  useEffect(() => {
+    handleNickNameMessage(info.nickName);
+  }, [info.nickName, handleNickNameMessage]);
+
+  useEffect(() => {
+    handleBirthMessage(info.birth);
+  }, [info.birth, handleBirthMessage]);
+
+  return {
+    info,
+    handleInfoChange,
+    handleNickNameMessage,
+    handleBirthMessage,
+    nickNameSupportingText,
+    birthSupportingText,
+    isNickNameError,
+    isBirthError,
+  };
+};

--- a/src/pages/SignupPage/hooks/useInfoForm.ts
+++ b/src/pages/SignupPage/hooks/useInfoForm.ts
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
-
 import { SUPPORTING_TEXT } from "@/pages/SignupPage/constants/supportingText";
 import { formatDate } from "@/pages/SignupPage/utils/date";
+import { useCallback, useEffect, useState } from "react";
 
 type InfoFormKeys = "name" | "nickName" | "birth";
 
@@ -17,17 +16,14 @@ export const useInfoForm = () => {
   const [nickNameSupportingText, setNickNameSupportingText] = useState("");
   const [birthSupportingText, setBirthSupportingText] = useState("");
 
-  const handleInfoChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>, key: InfoFormKeys) => {
-      const { value } = e.target;
+  const handleInfoChange = useCallback((e: React.ChangeEvent<HTMLInputElement>, key: InfoFormKeys) => {
+    const { value } = e.target;
 
-      setInfo((prev) => ({
-        ...prev,
-        [key]: value,
-      }));
-    },
-    []
-  );
+    setInfo((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  }, []);
 
   const handleNickNameMessage = useCallback((nickName: string) => {
     if (nickName.length < 2 || nickName.length > 10) {
@@ -45,11 +41,9 @@ export const useInfoForm = () => {
     }
   }, []);
 
-  const isNickNameError =
-    info.nickName.length > 0 &&
-    (info.nickName.length < 2 || info.nickName.length > 10);
-  const isBirthError =
-    info.birth.length > 0 && formatDate(info.birth).length !== 10;
+  const isNickNameError = info.nickName.length > 0 && (info.nickName.length < 2 || info.nickName.length > 10);
+
+  const isBirthError = info.birth.length > 0 && formatDate(info.birth).length !== 10;
 
   useEffect(() => {
     handleNickNameMessage(info.nickName);

--- a/src/pages/SignupPage/hooks/useInfoForm.ts
+++ b/src/pages/SignupPage/hooks/useInfoForm.ts
@@ -5,10 +5,12 @@ import { SUPPORTING_TEXT } from "@/pages/SignupPage/constants/supportingText";
 type InfoFormKeys = "name" | "nickName" | "birth";
 
 export const useInfoForm = () => {
+  const formData = JSON.parse(sessionStorage.getItem("signup") || "{}");
+
   const [info, setInfo] = useState({
-    name: "",
-    nickName: "",
-    birth: "",
+    name: formData.name || "",
+    nickName: formData.nickName || "",
+    birth: formData.birth || "",
   });
 
   const [nickNameSupportingText, setNickNameSupportingText] = useState("");
@@ -35,7 +37,7 @@ export const useInfoForm = () => {
   }, []);
 
   const handleBirthMessage = useCallback((birth: string) => {
-    if (birth.length !== 8) {
+    if (birth.length !== 10) {
       setBirthSupportingText(SUPPORTING_TEXT.BIRTH);
 
       return SUPPORTING_TEXT.BIRTH;
@@ -45,7 +47,7 @@ export const useInfoForm = () => {
   const isNickNameError =
     info.nickName.length > 0 &&
     (info.nickName.length < 2 || info.nickName.length > 10);
-  const isBirthError = info.birth.length > 0 && info.birth.length !== 8;
+  const isBirthError = info.birth.length > 0 && info.birth.length !== 10;
 
   useEffect(() => {
     handleNickNameMessage(info.nickName);

--- a/src/pages/SignupPage/hooks/useInfoForm.ts
+++ b/src/pages/SignupPage/hooks/useInfoForm.ts
@@ -16,14 +16,26 @@ export const useInfoForm = () => {
   const [nickNameSupportingText, setNickNameSupportingText] = useState("");
   const [birthSupportingText, setBirthSupportingText] = useState("");
 
-  const handleInfoChange = useCallback((e: React.ChangeEvent<HTMLInputElement>, key: InfoFormKeys) => {
-    const { value } = e.target;
+  const handleInfoChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>, key: InfoFormKeys) => {
+      const { value } = e.target;
 
-    setInfo((prev) => ({
-      ...prev,
-      [key]: value,
-    }));
-  }, []);
+      setInfo((prev) => ({
+        ...prev,
+        [key]: value,
+      }));
+
+      sessionStorage.setItem(
+        "signup",
+        JSON.stringify({
+          name: info.name,
+          nickName: info.nickName,
+          birth: formatDate(info.birth),
+        }),
+      );
+    },
+    [info.birth, info.name, info.nickName],
+  );
 
   const handleNickNameMessage = useCallback((nickName: string) => {
     if (nickName.length < 2 || nickName.length > 10) {
@@ -34,7 +46,7 @@ export const useInfoForm = () => {
   }, []);
 
   const handleBirthMessage = useCallback((birth: string) => {
-    if (birth.length !== 10) {
+    if (formatDate(birth).length !== 10) {
       setBirthSupportingText(SUPPORTING_TEXT.BIRTH);
 
       return SUPPORTING_TEXT.BIRTH;

--- a/src/pages/SignupPage/hooks/useInfoForm.ts
+++ b/src/pages/SignupPage/hooks/useInfoForm.ts
@@ -1,46 +1,45 @@
 import { SUPPORTING_TEXT } from "@/pages/SignupPage/constants/supportingText";
+import {
+  type signUpFormTypes,
+  defaultSignUpFormValues,
+} from "@/pages/SignupPage/types/signUpFormTypes";
 import { formatDate } from "@/pages/SignupPage/utils/date";
 import { useCallback, useEffect, useState } from "react";
-
-type InfoFormKeys = "name" | "nickName" | "birth";
 
 export const useInfoForm = () => {
   const formData = JSON.parse(sessionStorage.getItem("signup") || "{}");
 
-  const [info, setInfo] = useState({
-    name: formData.name || "",
-    nickName: formData.nickName || "",
-    birth: formData.birth || "",
+  const [form, setForm] = useState({
+    ...defaultSignUpFormValues,
+    ...formData,
   });
 
   const [nickNameSupportingText, setNickNameSupportingText] = useState("");
   const [birthSupportingText, setBirthSupportingText] = useState("");
 
   const handleInfoChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>, key: InfoFormKeys) => {
-      const { value } = e.target;
-
-      setInfo((prev) => ({
+    (e: React.ChangeEvent<HTMLInputElement>, key: keyof signUpFormTypes) => {
+      setForm((prev: signUpFormTypes) => ({
         ...prev,
-        [key]: value,
+        [key]: e.target.value,
       }));
 
       sessionStorage.setItem(
         "signup",
         JSON.stringify({
-          name: info.name,
-          nickName: info.nickName,
-          birth: formatDate(info.birth),
-        }),
+          ...form,
+          name: form.name,
+          nickName: form.nickName,
+          birth: formatDate(form.birth),
+        })
       );
     },
-    [info.birth, info.name, info.nickName],
+    [form]
   );
 
   const handleNickNameMessage = useCallback((nickName: string) => {
     if (nickName.length < 2 || nickName.length > 10) {
       setNickNameSupportingText(SUPPORTING_TEXT.NICKNAME);
-
       return SUPPORTING_TEXT.NICKNAME;
     }
   }, []);
@@ -48,25 +47,27 @@ export const useInfoForm = () => {
   const handleBirthMessage = useCallback((birth: string) => {
     if (formatDate(birth).length !== 10) {
       setBirthSupportingText(SUPPORTING_TEXT.BIRTH);
-
       return SUPPORTING_TEXT.BIRTH;
     }
   }, []);
 
-  const isNickNameError = info.nickName.length > 0 && (info.nickName.length < 2 || info.nickName.length > 10);
+  const isNickNameError =
+    form.nickName.length > 0 &&
+    (form.nickName.length < 2 || form.nickName.length > 10);
 
-  const isBirthError = info.birth.length > 0 && formatDate(info.birth).length !== 10;
+  const isBirthError =
+    form.birth.length > 0 && formatDate(form.birth).length !== 10;
 
   useEffect(() => {
-    handleNickNameMessage(info.nickName);
-  }, [info.nickName, handleNickNameMessage]);
+    handleNickNameMessage(form.nickName);
+  }, [form.nickName, handleNickNameMessage]);
 
   useEffect(() => {
-    handleBirthMessage(info.birth);
-  }, [info.birth, handleBirthMessage]);
+    handleBirthMessage(form.birth);
+  }, [form.birth, handleBirthMessage]);
 
   return {
-    info,
+    form,
     handleInfoChange,
     handleNickNameMessage,
     handleBirthMessage,

--- a/src/pages/SignupPage/hooks/useInfoForm.ts
+++ b/src/pages/SignupPage/hooks/useInfoForm.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { SUPPORTING_TEXT } from "@/pages/SignupPage/constants/supportingText";
+import { formatDate } from "@/pages/SignupPage/utils/date";
 
 type InfoFormKeys = "name" | "nickName" | "birth";
 
@@ -47,7 +48,8 @@ export const useInfoForm = () => {
   const isNickNameError =
     info.nickName.length > 0 &&
     (info.nickName.length < 2 || info.nickName.length > 10);
-  const isBirthError = info.birth.length > 0 && info.birth.length !== 10;
+  const isBirthError =
+    info.birth.length > 0 && formatDate(info.birth).length !== 10;
 
   useEffect(() => {
     handleNickNameMessage(info.nickName);

--- a/src/pages/SignupPage/hooks/useInterestSelection.ts
+++ b/src/pages/SignupPage/hooks/useInterestSelection.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState } from "react";
+
+export const useInterestSelection = () => {
+  const formData = JSON.parse(sessionStorage.getItem("signup") || "{}");
+  const initialSelection = Array.isArray(formData.interests)
+    ? [formData.interests]
+    : [];
+
+  const [interests, setInterests] = useState<string[]>(initialSelection);
+
+  const handleCheckboxChange = useCallback((interest: string) => {
+    setInterests((prev) =>
+      prev.includes(interest)
+        ? prev.filter((item) => item !== interest)
+        : [...prev, interest]
+    );
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setInterests([]);
+  }, []);
+
+  return {
+    interests,
+    handleCheckboxChange,
+    handleReset,
+  };
+};

--- a/src/pages/SignupPage/hooks/useInterestSelection.ts
+++ b/src/pages/SignupPage/hooks/useInterestSelection.ts
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 export const useInterestSelection = () => {
   const formData = JSON.parse(sessionStorage.getItem("signup") || "{}");
   const initialSelection = Array.isArray(formData.interests)
-    ? [formData.interests]
+    ? formData.interests
     : [];
 
   const [interests, setInterests] = useState<string[]>(initialSelection);
@@ -16,9 +16,9 @@ export const useInterestSelection = () => {
     );
   }, []);
 
-  const handleReset = useCallback(() => {
+  const handleReset = () => {
     setInterests([]);
-  }, []);
+  };
 
   return {
     interests,

--- a/src/pages/SignupPage/hooks/useInterestSelection.ts
+++ b/src/pages/SignupPage/hooks/useInterestSelection.ts
@@ -1,26 +1,40 @@
+import { type signUpFormTypes } from "@/pages/SignupPage/types/signupFormTypes";
 import { useCallback, useState } from "react";
 
 export const useInterestSelection = () => {
-  const formData = JSON.parse(sessionStorage.getItem("signup") || "{}");
-  const initialSelection = Array.isArray(formData.interests) ? formData.interests : [];
+  const formData: Partial<signUpFormTypes> = JSON.parse(
+    sessionStorage.getItem("signup") || "{}"
+  );
+  const initialSelection = Array.isArray(formData.interests)
+    ? formData.interests
+    : [];
 
   const [interests, setInterests] = useState<string[]>(initialSelection);
 
-  const handleCheckboxChange = useCallback(
-    (interest: string) => {
-      setInterests((prev) =>
-        prev.includes(interest) ? prev.filter((item) => item !== interest) : [...prev, interest],
+  const handleCheckboxChange = useCallback((interest: string) => {
+    setInterests((prev) => {
+      const updatedInterests = prev.includes(interest)
+        ? prev.filter((item) => item !== interest)
+        : [...prev, interest];
+
+      const prevData = JSON.parse(sessionStorage.getItem("signup") || "{}");
+      sessionStorage.setItem(
+        "signup",
+        JSON.stringify({ ...prevData, interests: updatedInterests })
       );
 
-      const prev = JSON.parse(sessionStorage.getItem("signup") || "{}");
-      sessionStorage.setItem("signup", JSON.stringify({ ...prev, interests }));
-    },
-    [interests],
-  );
+      return updatedInterests;
+    });
+  }, []);
 
-  const handleReset = () => {
+  const handleReset = useCallback(() => {
     setInterests([]);
-  };
+    const prevData = JSON.parse(sessionStorage.getItem("signup") || "{}");
+    sessionStorage.setItem(
+      "signup",
+      JSON.stringify({ ...prevData, interests: [] })
+    );
+  }, []);
 
   return {
     interests,

--- a/src/pages/SignupPage/hooks/useInterestSelection.ts
+++ b/src/pages/SignupPage/hooks/useInterestSelection.ts
@@ -2,19 +2,21 @@ import { useCallback, useState } from "react";
 
 export const useInterestSelection = () => {
   const formData = JSON.parse(sessionStorage.getItem("signup") || "{}");
-  const initialSelection = Array.isArray(formData.interests)
-    ? formData.interests
-    : [];
+  const initialSelection = Array.isArray(formData.interests) ? formData.interests : [];
 
   const [interests, setInterests] = useState<string[]>(initialSelection);
 
-  const handleCheckboxChange = useCallback((interest: string) => {
-    setInterests((prev) =>
-      prev.includes(interest)
-        ? prev.filter((item) => item !== interest)
-        : [...prev, interest]
-    );
-  }, []);
+  const handleCheckboxChange = useCallback(
+    (interest: string) => {
+      setInterests((prev) =>
+        prev.includes(interest) ? prev.filter((item) => item !== interest) : [...prev, interest],
+      );
+
+      const prev = JSON.parse(sessionStorage.getItem("signup") || "{}");
+      sessionStorage.setItem("signup", JSON.stringify({ ...prev, interests }));
+    },
+    [interests],
+  );
 
   const handleReset = () => {
     setInterests([]);

--- a/src/pages/SignupPage/hooks/useProfileForm.ts
+++ b/src/pages/SignupPage/hooks/useProfileForm.ts
@@ -1,3 +1,7 @@
+import {
+  type signUpFormTypes,
+  defaultSignUpFormValues,
+} from "@/pages/SignupPage/types/signupFormTypes";
 import { useCallback, useState } from "react";
 
 type FormKeys = "belonging" | "introduction";
@@ -6,28 +10,34 @@ export const useProfileForm = () => {
   const formData = JSON.parse(sessionStorage.getItem("signup") || "{}");
 
   const [form, setForm] = useState({
-    belonging: formData.belonging || "",
-    introduction: formData.introduction || "",
+    ...defaultSignUpFormValues,
+    ...formData,
   });
 
   const handleFormChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, key: FormKeys) => {
-      setForm((prev) => ({
-        ...prev,
-        [key]: e.target.value,
-      }));
+    (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+      key: FormKeys
+    ) => {
+      setForm((prev: signUpFormTypes) => {
+        const updatedForm = {
+          ...prev,
+          [key]: e.target.value,
+        };
 
-      const prev = JSON.parse(sessionStorage.getItem("signup") || "{}");
+        sessionStorage.setItem(
+          "signup",
+          JSON.stringify({
+            ...updatedForm,
+            belonging: updatedForm.belonging,
+            introduction: updatedForm.introduction,
+          })
+        );
 
-      const data = {
-        ...prev,
-        belonging: form.belonging,
-        introduction: form.introduction,
-      };
-
-      sessionStorage.setItem("signup", JSON.stringify(data));
+        return updatedForm;
+      });
     },
-    [form.belonging, form.introduction],
+    []
   );
 
   return {

--- a/src/pages/SignupPage/hooks/useProfileForm.ts
+++ b/src/pages/SignupPage/hooks/useProfileForm.ts
@@ -1,0 +1,27 @@
+import { useState } from "react";
+
+type FormKeys = "belonging" | "introduction";
+
+export const useProfileForm = () => {
+  const formData = JSON.parse(sessionStorage.getItem("signup") || "{}");
+
+  const [form, setForm] = useState({
+    belonging: formData.belonging || "",
+    introduction: formData.introduction || "",
+  });
+
+  const handleFormChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    key: FormKeys
+  ) => {
+    setForm((prev) => ({
+      ...prev,
+      [key]: e.target.value,
+    }));
+  };
+
+  return {
+    form,
+    handleFormChange,
+  };
+};

--- a/src/pages/SignupPage/hooks/useProfileForm.ts
+++ b/src/pages/SignupPage/hooks/useProfileForm.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 type FormKeys = "belonging" | "introduction";
 
@@ -10,15 +10,18 @@ export const useProfileForm = () => {
     introduction: formData.introduction || "",
   });
 
-  const handleFormChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-    key: FormKeys
-  ) => {
-    setForm((prev) => ({
-      ...prev,
-      [key]: e.target.value,
-    }));
-  };
+  const handleFormChange = useCallback(
+    (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+      key: FormKeys
+    ) => {
+      setForm((prev) => ({
+        ...prev,
+        [key]: e.target.value,
+      }));
+    },
+    []
+  );
 
   return {
     form,

--- a/src/pages/SignupPage/hooks/useProfileForm.ts
+++ b/src/pages/SignupPage/hooks/useProfileForm.ts
@@ -11,16 +11,23 @@ export const useProfileForm = () => {
   });
 
   const handleFormChange = useCallback(
-    (
-      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-      key: FormKeys
-    ) => {
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, key: FormKeys) => {
       setForm((prev) => ({
         ...prev,
         [key]: e.target.value,
       }));
+
+      const prev = JSON.parse(sessionStorage.getItem("signup") || "{}");
+
+      const data = {
+        ...prev,
+        belonging: form.belonging,
+        introduction: form.introduction,
+      };
+
+      sessionStorage.setItem("signup", JSON.stringify(data));
     },
-    []
+    [form.belonging, form.introduction],
   );
 
   return {

--- a/src/pages/SignupPage/hooks/useUrlForm.ts
+++ b/src/pages/SignupPage/hooks/useUrlForm.ts
@@ -1,0 +1,22 @@
+import { useCallback, useState } from "react";
+
+export const useUrlForm = () => {
+  const formData = JSON.parse(sessionStorage.getItem("signup") || "{}");
+  const initialUrls = Array.isArray(formData.urls) ? formData.urls : [""];
+
+  const [urls, setUrls] = useState<string[]>(initialUrls);
+
+  const handleAddInput = useCallback(() => {
+    setUrls((prev) => [...prev, ""]);
+  }, []);
+
+  const handleChange = useCallback((index: number, value: string) => {
+    setUrls((prev) => prev.map((url, i) => (i === index ? value : url)));
+  }, []);
+
+  return {
+    urls,
+    handleAddInput,
+    handleChange,
+  };
+};

--- a/src/pages/SignupPage/hooks/useUrlForm.ts
+++ b/src/pages/SignupPage/hooks/useUrlForm.ts
@@ -10,16 +10,22 @@ export const useUrlForm = () => {
     setUrls((prev) => [...prev, ""]);
   }, []);
 
-  const handleChange = useCallback(
-    (index: number, value: string) => {
-      setUrls((prev) => prev.map((url, i) => (i === index ? value : url)));
+  const handleChange = useCallback((index: number, value: string) => {
+    setUrls((prev: string[]) => {
+      let updatedUrls = prev.map((url, i) => (i === index ? value : url));
 
-      const prev = JSON.parse(sessionStorage.getItem("signup") || "{}");
+      if (updatedUrls.every((url) => url === "")) {
+        updatedUrls = [""];
+      }
 
-      sessionStorage.setItem("signup", JSON.stringify({ ...prev, urls }));
-    },
-    [urls],
-  );
+      sessionStorage.setItem(
+        "signup",
+        JSON.stringify({ ...formData, urls: updatedUrls })
+      );
+
+      return updatedUrls;
+    });
+  }, []);
 
   return {
     urls,

--- a/src/pages/SignupPage/hooks/useUrlForm.ts
+++ b/src/pages/SignupPage/hooks/useUrlForm.ts
@@ -10,9 +10,16 @@ export const useUrlForm = () => {
     setUrls((prev) => [...prev, ""]);
   }, []);
 
-  const handleChange = useCallback((index: number, value: string) => {
-    setUrls((prev) => prev.map((url, i) => (i === index ? value : url)));
-  }, []);
+  const handleChange = useCallback(
+    (index: number, value: string) => {
+      setUrls((prev) => prev.map((url, i) => (i === index ? value : url)));
+
+      const prev = JSON.parse(sessionStorage.getItem("signup") || "{}");
+
+      sessionStorage.setItem("signup", JSON.stringify({ ...prev, urls }));
+    },
+    [urls],
+  );
 
   return {
     urls,

--- a/src/pages/SignupPage/types/signupFormTypes.ts
+++ b/src/pages/SignupPage/types/signupFormTypes.ts
@@ -1,0 +1,19 @@
+export interface signUpFormTypes {
+  belonging: string;
+  birth: string;
+  interests: string[];
+  introduction: string;
+  name: string;
+  nickName: string;
+  urls: string[];
+}
+
+export const defaultSignUpFormValues: signUpFormTypes = {
+  belonging: "",
+  birth: "",
+  interests: [],
+  introduction: "",
+  name: "",
+  nickName: "",
+  urls: [""],
+};

--- a/src/pages/SignupPage/utils/date.ts
+++ b/src/pages/SignupPage/utils/date.ts
@@ -1,0 +1,10 @@
+export const formatDate = (date: string) => {
+  if (!/^\d{8}$/.test(date)) {
+    return date;
+  }
+  const year = date.slice(0, 4);
+  const month = date.slice(4, 6);
+  const day = date.slice(6, 8);
+
+  return `${year}.${month}.${day}`;
+};


### PR DESCRIPTION
## 🎯 관련 이슈

close #24

<br />

## 🚀 작업 내용

- session storage를 사용해서 데이터를 저장해줬습니다

- 어떤 방식으로 데이터를 저장하고 넘길지 고민을 좀 해봤는데 context를 쓰기에는 전역에 전달되는 데이터가 아니고, signupPage에서 전체 폼데이터를 관리하게 되면 이전 스텝으로 돌아갈 때 데이터가 보존되지 않더라고요 
세션 스토리지를 사용하게 되면 보안상의 이슈가 있긴 하지만 마지막 스탭에서 넘어갈 때 sessionStorage.clear를 해줬습니다.


<br />


## 📸 스크린샷



https://github.com/user-attachments/assets/6a7d89bb-0e08-432c-8163-c39b8d768257



<br />


<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
