### PR TITLE
#67 [FEAT] 아이콘만 있는 메뉴 헤더

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,14 @@
 import { MenuHeader, ServerHeader } from "@/components";
 import { theme } from "@/styles/theme/theme";
+import { css } from "@emotion/react";
 import { Outlet } from "react-router-dom";
 
-const App = () => {
+const App = ({ iconMenuHeader }: { iconMenuHeader?: boolean }) => {
   return (
-    <div css={{ display: "flex", overflow: "hidden" }}>
+    <div css={layoutStyle}>
       <div css={{ display: "flex", borderRadius: "0 2.5rem 2.5rem 0", backgroundColor: theme.color.dark3 }}>
         <ServerHeader />
-        <MenuHeader />
+        <MenuHeader iconOnly={iconMenuHeader} />
       </div>
 
       <Outlet />
@@ -16,3 +17,9 @@ const App = () => {
 };
 
 export default App;
+
+export const layoutStyle = css`
+  display: flex;
+
+  overflow: hidden;
+`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,10 @@ import { Outlet } from "react-router-dom";
 const App = ({ iconMenuHeader }: { iconMenuHeader?: boolean }) => {
   return (
     <div css={layoutStyle}>
-      <div css={{ display: "flex", borderRadius: "0 2.5rem 2.5rem 0", backgroundColor: theme.color.dark3 }}>
+      <div css={headerStyle}>
         <ServerHeader />
         <MenuHeader iconOnly={iconMenuHeader} />
       </div>
-
       <Outlet />
     </div>
   );
@@ -20,6 +19,11 @@ export default App;
 
 export const layoutStyle = css`
   display: flex;
-
   overflow: hidden;
+`;
+
+export const headerStyle = css`
+  display: flex;
+  border-radius: 0 2.5rem 2.5rem 0;
+  background-color: ${theme.color.dark3};
 `;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,18 @@
 import { MenuHeader, ServerHeader } from "@/components";
-import { css } from "@emotion/react";
+import { theme } from "@/styles/theme/theme";
 import { Outlet } from "react-router-dom";
 
 const App = () => {
   return (
-    <div css={layoutStyle}>
-      <ServerHeader />
-      <MenuHeader />
+    <div css={{ display: "flex", overflow: "hidden" }}>
+      <div css={{ display: "flex", borderRadius: "0 2.5rem 2.5rem 0", backgroundColor: theme.color.dark3 }}>
+        <ServerHeader />
+        <MenuHeader />
+      </div>
+
       <Outlet />
     </div>
   );
 };
 
 export default App;
-
-export const layoutStyle = css`
-  display: flex;
-
-  overflow: hidden;
-`;

--- a/src/components/MenuHeader/MenuHeader.styles.ts
+++ b/src/components/MenuHeader/MenuHeader.styles.ts
@@ -1,34 +1,48 @@
 import { theme } from "@/styles/theme/theme";
 import { css } from "@emotion/react";
 
-export const containerStyle = css`
+export const containerStyle = (iconOnly: boolean) => css`
   display: flex;
   flex-direction: column;
-  gap: 1.8rem;
-  width: 23.2rem;
+
+  gap: ${iconOnly ? "2rem" : "1.8rem"};
+
+  padding: ${iconOnly ? "4.4rem 1.8rem" : "2.8rem 3.4rem"};
+
+  width: ${iconOnly ? "9.3rem" : "23.2rem"};
   height: 100vh;
-  padding: 2.8rem 3.4rem;
-  border-radius: 2.5rem;
+
+  border-radius: 0 2.5rem 2.5rem 0;
+
   background-color: ${theme.color.dark3};
 `;
 
 export const menuListStyle = css`
   display: flex;
   flex-direction: column;
+
   align-items: baseline;
-  row-gap: 1.4rem;
+
+  gap: 1.4rem;
+
   width: 100%;
 `;
 
-export const menuItemStyle = css`
+export const menuItemStyle = (iconOnly: boolean) => css`
   display: flex;
+
   align-items: center;
+
   gap: 1.4rem;
+
+  padding: ${iconOnly ? "1.5rem 1.7rem" : "1.8rem 2rem"};
+
   width: 100%;
   height: 5rem;
-  padding: 1.8rem 2rem;
+
   border: 1px solid ${theme.color.dark1};
   border-radius: 1rem;
+
   transition: border-color 0.3s ease, background-color 0.3s ease;
 
   svg {
@@ -43,6 +57,7 @@ export const menuItemStyle = css`
   span {
     margin: 0;
     padding: 0;
+
     ${theme.font.body1};
     font-weight: 500;
     color: ${theme.color.white};
@@ -50,7 +65,9 @@ export const menuItemStyle = css`
 
   :hover {
     border-color: ${theme.color.primaryBlue2};
+
     background-color: ${theme.color.primaryBlue2};
+
     scale: 1.05;
 
     svg path {
@@ -61,6 +78,7 @@ export const menuItemStyle = css`
 
 export const activeMenuItemStyle = css`
   border-color: ${theme.color.primaryBlue2};
+
   background-color: ${theme.color.primaryBlue2};
 
   svg path {

--- a/src/components/MenuHeader/MenuHeader.tsx
+++ b/src/components/MenuHeader/MenuHeader.tsx
@@ -1,6 +1,7 @@
 import { Logo4Icon, RotateLogoIcon } from "@/assets/svg";
 import { MENU } from "@/constants/menu";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useGlobalServer } from "@/stores/useGlobalServerStore"; // Import the global server state hook
+import { useLocation, useNavigate } from "react-router-dom";
 import * as s from "./MenuHeader.styles";
 
 interface MenuHeaderProps {
@@ -10,7 +11,10 @@ interface MenuHeaderProps {
 const MenuHeader = ({ iconOnly = false }: MenuHeaderProps) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { serverId } = useParams();
+
+  const globalServer = useGlobalServer();
+
+  const serverId = globalServer?.id;
 
   const handleNavigate = (menu: string) => {
     if (!serverId) return;

--- a/src/components/MenuHeader/MenuHeader.tsx
+++ b/src/components/MenuHeader/MenuHeader.tsx
@@ -1,5 +1,6 @@
 import { Logo4Icon, RotateLogoIcon } from "@/assets/svg";
-import { MENU } from "@/constants/menu";
+import { MENUS, type MenuTypes } from "@/constants/menu";
+import { useGlobalMenuAction } from "@/stores/useGlobalMenuStore";
 import { useGlobalServer } from "@/stores/useGlobalServerStore"; // Import the global server state hook
 import { useLocation, useNavigate } from "react-router-dom";
 import * as s from "./MenuHeader.styles";
@@ -13,16 +14,18 @@ const MenuHeader = ({ iconOnly = false }: MenuHeaderProps) => {
   const location = useLocation();
 
   const globalServer = useGlobalServer();
-
   const serverId = globalServer?.id;
 
-  const handleNavigate = (menu: string) => {
+  const { setGlobalMenu } = useGlobalMenuAction();
+
+  const handleNavigate = (menu: MenuTypes) => {
     if (!serverId) return;
-    navigate(`/${serverId}/${menu}`);
+    setGlobalMenu(menu);
+    navigate(`/${serverId}/${menu.id}`);
   };
 
-  const isActiveMenu = (menu: string) => {
-    return location.pathname.startsWith(`/${serverId}/${menu}`);
+  const isActiveMenu = (menuId: string) => {
+    return location.pathname.startsWith(`/${serverId}/${menuId}`);
   };
 
   return (
@@ -33,12 +36,12 @@ const MenuHeader = ({ iconOnly = false }: MenuHeaderProps) => {
         <Logo4Icon />
       )}
       <div css={s.menuListStyle}>
-        {MENU.map((menu) => (
+        {MENUS.map((menu) => (
           <button
             key={menu.id}
             type="button"
-            css={[s.menuItemStyle(iconOnly), isActiveMenu(menu.path) && s.activeMenuItemStyle]}
-            onClick={() => handleNavigate(menu.path)}
+            css={[s.menuItemStyle(iconOnly), isActiveMenu(menu.id) && s.activeMenuItemStyle]}
+            onClick={() => handleNavigate(menu)}
           >
             <menu.icon />
             {!iconOnly && <span css={{ whiteSpace: "nowrap" }}>{menu.name}</span>}

--- a/src/components/MenuHeader/MenuHeader.tsx
+++ b/src/components/MenuHeader/MenuHeader.tsx
@@ -1,9 +1,13 @@
-import { Logo4Icon } from "@/assets/svg";
+import { Logo4Icon, RotateLogoIcon } from "@/assets/svg";
 import { MENU } from "@/constants/menu";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import * as s from "./MenuHeader.styles";
 
-const MenuHeader = () => {
+interface MenuHeaderProps {
+  iconOnly?: boolean;
+}
+
+const MenuHeader = ({ iconOnly = false }: MenuHeaderProps) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { serverId } = useParams();
@@ -18,25 +22,24 @@ const MenuHeader = () => {
   };
 
   return (
-    <header css={s.containerStyle}>
-      <Logo4Icon />
+    <header css={s.containerStyle(iconOnly)}>
+      {iconOnly ? (
+        <RotateLogoIcon width={55} height={53} css={{ padding: "1rem", cursor: "pointer" }} />
+      ) : (
+        <Logo4Icon />
+      )}
       <div css={s.menuListStyle}>
-        {MENU.map((menu) => {
-          return (
-            <button
-              key={menu.id}
-              type="button"
-              css={[
-                s.menuItemStyle,
-                isActiveMenu(menu.path) && s.activeMenuItemStyle,
-              ]}
-              onClick={() => handleNavigate(menu.path)}
-            >
-              <menu.icon />
-              <span css={{ whiteSpace: "nowrap" }}>{menu.name}</span>
-            </button>
-          );
-        })}
+        {MENU.map((menu) => (
+          <button
+            key={menu.id}
+            type="button"
+            css={[s.menuItemStyle(iconOnly), isActiveMenu(menu.path) && s.activeMenuItemStyle]}
+            onClick={() => handleNavigate(menu.path)}
+          >
+            <menu.icon />
+            {!iconOnly && <span css={{ whiteSpace: "nowrap" }}>{menu.name}</span>}
+          </button>
+        ))}
       </div>
     </header>
   );

--- a/src/components/ServerHeader/ServerHeader.tsx
+++ b/src/components/ServerHeader/ServerHeader.tsx
@@ -1,6 +1,7 @@
 import { PlusIcon } from "@/assets/svg";
 import ServerDropdown from "@/components/ServerHeader/components/ServerDropdown/ServerDropdown";
-import { GLOBAL_MENUS, type GlobalMenuTypes, SERVERINFO, type ServerInfoTypes } from "@/constants/serverInfo";
+import { GLOBAL_MENUS, type MenuTypes } from "@/constants/menu";
+import { SERVERINFO, type ServerInfoTypes } from "@/constants/serverInfo";
 import ScheduleSideModal from "@/pages/HomePage/components/ScheduleSideModal/ScheduleSideModal";
 import { useGlobalMenu, useGlobalMenuAction } from "@/stores/useGlobalMenuStore";
 import { useGlobalServer, useGlobalServerAction } from "@/stores/useGlobalServerStore";
@@ -23,7 +24,7 @@ const ServerHeader = () => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [isScheduleVisible, setIsScheduleVisible] = useState(false);
   const [hoveredGlobalMenuId, setHoveredGlobalMenuId] = useState<string | null>(null);
-  const [previousMenu, setPreviousMenu] = useState<GlobalMenuTypes | null>(globalMenu);
+  const [previousMenu, setPreviousMenu] = useState<MenuTypes | null>(globalMenu);
 
   const myServerSet = new Set(myServerIdList);
 
@@ -31,7 +32,7 @@ const ServerHeader = () => {
     ? SERVERINFO.filter((server) => myServerSet.has(server.id) && server.id !== currentServer.id)
     : [];
 
-  const handleGlobalMenuClick = (menu: GlobalMenuTypes | null) => {
+  const handleGlobalMenuClick = (menu: MenuTypes) => {
     setPreviousMenu(globalMenu);
     setGlobalMenu(menu);
     menu?.id === "schedule" ? setIsScheduleVisible(true) : navigate(`/${menu?.id}`);

--- a/src/components/ServerHeader/ServerHeader.tsx
+++ b/src/components/ServerHeader/ServerHeader.tsx
@@ -1,8 +1,9 @@
 import { PlusIcon } from "@/assets/svg";
 import ServerDropdown from "@/components/ServerHeader/components/ServerDropdown/ServerDropdown";
-import { GLOBAL_MENUS, type GlobalMenuTypes, SERVERINFO, type ServerInfoType } from "@/constants/serverInfo";
+import { GLOBAL_MENUS, type GlobalMenuTypes, SERVERINFO, type ServerInfoTypes } from "@/constants/serverInfo";
 import ScheduleSideModal from "@/pages/HomePage/components/ScheduleSideModal/ScheduleSideModal";
 import { useGlobalMenu, useGlobalMenuAction } from "@/stores/useGlobalMenuStore";
+import { useGlobalServer, useGlobalServerAction } from "@/stores/useGlobalServerStore";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import * as s from "./ServerHeader.styles";
@@ -10,15 +11,19 @@ import * as s from "./ServerHeader.styles";
 const ServerHeader = () => {
   const navigate = useNavigate();
   const globalMenu = useGlobalMenu();
+  const globalServer = useGlobalServer();
+
   const { setGlobalMenu } = useGlobalMenuAction();
+  const { setGlobalServer } = useGlobalServerAction();
 
   const [myServerIdList] = useState<number[]>([2, 6, 10, 15, 22]);
   const currentServerInfo = SERVERINFO.find((server) => server.id === myServerIdList[0]);
-  const [currentServer, setCurrentServer] = useState<ServerInfoType | undefined>(currentServerInfo);
-  const [prevGlobalMenu, setPrevGlobalMenu] = useState(globalMenu);
+
+  const [currentServer, setCurrentServer] = useState<ServerInfoTypes | undefined>(currentServerInfo);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [isScheduleVisible, setIsScheduleVisible] = useState(false);
   const [hoveredGlobalMenuId, setHoveredGlobalMenuId] = useState<string | null>(null);
+  const [previousMenu, setPreviousMenu] = useState<GlobalMenuTypes | null>(globalMenu);
 
   const myServerSet = new Set(myServerIdList);
 
@@ -27,20 +32,23 @@ const ServerHeader = () => {
     : [];
 
   const handleGlobalMenuClick = (menu: GlobalMenuTypes | null) => {
-    setPrevGlobalMenu(globalMenu);
+    setPreviousMenu(globalMenu);
     setGlobalMenu(menu);
-    if (menu?.id === "schedule") {
-      setIsScheduleVisible(true);
-    } else {
-      navigate(`/${menu?.id}`);
-    }
+    menu?.id === "schedule" ? setIsScheduleVisible(true) : navigate(`/${menu?.id}`);
+  };
+
+  const handleServerChange = (server: ServerInfoTypes) => {
+    setGlobalServer(server);
+    setCurrentServer(server);
   };
 
   useEffect(() => {
-    if (!isScheduleVisible && globalMenu?.id === "schedule") {
-      setGlobalMenu(prevGlobalMenu);
-    }
-  }, [globalMenu, isScheduleVisible, prevGlobalMenu, setGlobalMenu]);
+    !isScheduleVisible && globalMenu?.id === "schedule" && setGlobalMenu(previousMenu);
+  }, [isScheduleVisible, globalMenu, previousMenu, setGlobalMenu]);
+
+  useEffect(() => {
+    globalServer && setCurrentServer(globalServer);
+  }, [globalServer]);
 
   return (
     <header css={s.containerStyle}>
@@ -51,6 +59,7 @@ const ServerHeader = () => {
           setCurrentServer={setCurrentServer}
           dropdownOpen={dropdownOpen}
           setDropdownOpen={setDropdownOpen}
+          onServerChange={handleServerChange}
         />
         <button type="button" css={s.plusButtonStyle}>
           <PlusIcon />

--- a/src/components/ServerHeader/ServerHeader.tsx
+++ b/src/components/ServerHeader/ServerHeader.tsx
@@ -47,10 +47,6 @@ const ServerHeader = () => {
     !isScheduleVisible && globalMenu?.id === "schedule" && setGlobalMenu(previousMenu);
   }, [isScheduleVisible, globalMenu, previousMenu, setGlobalMenu]);
 
-  useEffect(() => {
-    globalServer && setCurrentServer(globalServer);
-  }, [globalServer]);
-
   return (
     <header css={s.containerStyle}>
       <div css={s.topMenuStyle}>

--- a/src/components/ServerHeader/components/ServerDropdown/ServerDropdown.tsx
+++ b/src/components/ServerHeader/components/ServerDropdown/ServerDropdown.tsx
@@ -1,15 +1,16 @@
 import { ReturnIcon } from "@/assets/svg";
-import type { ServerInfoType } from "@/constants/serverInfo";
+import type { ServerInfoTypes } from "@/constants/serverInfo";
 import { useGlobalMenuAction } from "@/stores/useGlobalMenuStore";
 import { useLocation, useNavigate } from "react-router-dom";
 import * as s from "./ServerDropdown.styles";
 
 interface DropdownProps extends React.HTMLAttributes<HTMLUListElement> {
-  options: ServerInfoType[];
-  currentServer?: ServerInfoType | undefined;
-  setCurrentServer: (item: ServerInfoType) => void;
+  options: ServerInfoTypes[];
+  currentServer?: ServerInfoTypes | undefined;
+  setCurrentServer: (item: ServerInfoTypes) => void;
   dropdownOpen: boolean;
   setDropdownOpen: (open: boolean) => void;
+  onServerChange: (server: ServerInfoTypes) => void;
 }
 
 const ServerDropdown = ({
@@ -18,15 +19,17 @@ const ServerDropdown = ({
   setCurrentServer,
   dropdownOpen,
   setDropdownOpen,
+  onServerChange,
   ...props
 }: DropdownProps) => {
   const { resetGlobalMenu } = useGlobalMenuAction();
   const { pathname } = useLocation();
   const navigate = useNavigate();
 
-  const handleItemClick = (item: ServerInfoType) => {
+  const handleItemClick = (item: ServerInfoTypes) => {
     resetGlobalMenu();
     setCurrentServer(item);
+    onServerChange(item);
 
     const menu = pathname.split("/")[2] || "home";
 

--- a/src/constants/menu.ts
+++ b/src/constants/menu.ts
@@ -1,22 +1,56 @@
-import { ChatIcon, CoffeeIcon, HomeIcon } from "../assets/svg"; // 임시 아이콘
+import type { SVGProps } from "react";
+import {
+  CalendarMenuActiveIcon,
+  CalendarMenuIcon,
+  ChatIcon,
+  CoffeeIcon,
+  DmMenuActiveIcon,
+  DmMenuIcon,
+  HomeIcon,
+  ProfileMenuActiveIcon,
+  ProfileMenuIcon,
+} from "../assets/svg";
 
-export const MENU = [
+export type MenuTypes = {
+  id: string;
+  name: string;
+  icon: React.ElementType<SVGProps<SVGSVGElement>>;
+  activeIcon: React.ElementType<SVGProps<SVGSVGElement>>;
+};
+
+export const MENUS: MenuTypes[] = [
   {
     id: "home",
     name: "홈",
     icon: HomeIcon,
-    path: "home", // 상대 경로
+    activeIcon: HomeIcon,
   },
   {
     id: "group-chat",
     name: "그룹챗",
     icon: ChatIcon,
-    path: "group-chat",
+    activeIcon: ChatIcon,
   },
   {
     id: "coffee-chat",
     name: "커피챗",
     icon: CoffeeIcon,
-    path: "coffee-chat",
+    activeIcon: CoffeeIcon,
+  },
+];
+
+export const GLOBAL_MENUS: MenuTypes[] = [
+  { id: "dm", name: "DM", icon: DmMenuIcon, activeIcon: DmMenuActiveIcon },
+  {
+    id: "schedule",
+    name: "스케줄",
+    icon: CalendarMenuIcon,
+    activeIcon: CalendarMenuActiveIcon,
+  },
+  {
+    id: "mypage",
+    name: "마이페이지",
+    icon: ProfileMenuIcon,
+    activeIcon: ProfileMenuActiveIcon,
   },
 ];

--- a/src/constants/serverInfo.ts
+++ b/src/constants/serverInfo.ts
@@ -14,7 +14,7 @@ import {
   ProfileMenuIcon,
 } from "../assets/svg";
 
-export type ServerInfoType = {
+export type ServerInfoTypes = {
   id: number;
   name: string;
   icon: React.ElementType<SVGProps<SVGSVGElement>>;
@@ -26,7 +26,7 @@ export type GlobalMenuTypes = {
   activeIcon: React.ElementType<SVGProps<SVGSVGElement>>;
 };
 
-export const SERVERINFO: ServerInfoType[] = [
+export const SERVERINFO: ServerInfoTypes[] = [
   { id: 0, name: "광고/마케팅", icon: HomeIcon },
   { id: 1, name: "금융/보험/핀테크", icon: HomeIcon },
   { id: 2, name: "모빌리티/교통", icon: MobilityServerIcon },

--- a/src/constants/serverInfo.ts
+++ b/src/constants/serverInfo.ts
@@ -1,29 +1,17 @@
 import type { SVGProps } from "react";
 import {
   BeautyServerIcon,
-  CalendarMenuActiveIcon,
-  CalendarMenuIcon,
-  DmMenuActiveIcon,
-  DmMenuIcon,
   HealthServerIcon,
   HomeIcon,
   HomeLivingServerIcon,
   HrLawServerIcon,
   MobilityServerIcon,
-  ProfileMenuActiveIcon,
-  ProfileMenuIcon,
 } from "../assets/svg";
 
 export type ServerInfoTypes = {
   id: number;
   name: string;
   icon: React.ElementType<SVGProps<SVGSVGElement>>;
-};
-
-export type GlobalMenuTypes = {
-  id: string;
-  icon: React.ElementType<SVGProps<SVGSVGElement>>;
-  activeIcon: React.ElementType<SVGProps<SVGSVGElement>>;
 };
 
 export const SERVERINFO: ServerInfoTypes[] = [
@@ -51,18 +39,4 @@ export const SERVERINFO: ServerInfoTypes[] = [
   { id: 21, name: "환경/에너지", icon: HomeIcon },
   { id: 22, name: "헬스케어/바이오", icon: HealthServerIcon },
   { id: 23, name: "기타", icon: HomeIcon },
-];
-
-export const GLOBAL_MENUS: GlobalMenuTypes[] = [
-  { id: "dm", icon: DmMenuIcon, activeIcon: DmMenuActiveIcon },
-  {
-    id: "schedule",
-    icon: CalendarMenuIcon,
-    activeIcon: CalendarMenuActiveIcon,
-  },
-  {
-    id: "mypage",
-    icon: ProfileMenuIcon,
-    activeIcon: ProfileMenuActiveIcon,
-  },
 ];

--- a/src/pages/HomePage/HomePage.styles.ts
+++ b/src/pages/HomePage/HomePage.styles.ts
@@ -6,12 +6,13 @@ export const layoutStyle = css`
 
   gap: 4rem;
 
-  padding: 4.2rem 5rem 5rem 4.2rem;
+  padding: 4.2rem 5rem 0 4.2rem;
 
   width: calc(100vw - 32.6rem);
   height: 100vh;
 
-  overflow-x: scroll;
+  overflow: scroll;
+  ${scrollDarkStyle}
 `;
 
 export const leftLayoutStyle = css`
@@ -19,16 +20,4 @@ export const leftLayoutStyle = css`
   flex-direction: column;
 
   gap: 4rem;
-`;
-
-export const scrollLayoutStyle = css`
-  display: flex;
-  flex-direction: column;
-
-  gap: 4rem;
-
-  padding-right: 2rem;
-
-  overflow-y: scroll;
-  ${scrollDarkStyle}
 `;

--- a/src/pages/HomePage/HomePage.styles.ts
+++ b/src/pages/HomePage/HomePage.styles.ts
@@ -6,13 +6,12 @@ export const layoutStyle = css`
 
   gap: 4rem;
 
-  padding: 4.2rem 5rem 0 4.2rem;
+  padding: 4.2rem 5rem 5rem 4.2rem;
 
   width: calc(100vw - 32.6rem);
   height: 100vh;
 
-  overflow: scroll;
-  ${scrollDarkStyle}
+  overflow-x: scroll;
 `;
 
 export const leftLayoutStyle = css`
@@ -20,4 +19,16 @@ export const leftLayoutStyle = css`
   flex-direction: column;
 
   gap: 4rem;
+`;
+
+export const scrollLayoutStyle = css`
+  display: flex;
+  flex-direction: column;
+
+  gap: 4rem;
+
+  padding-right: 2rem;
+
+  overflow-y: scroll;
+  ${scrollDarkStyle}
 `;

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -39,33 +39,31 @@ const HomePage = () => {
         <div css={s.leftLayoutStyle}>
           <div css={s.leftLayoutStyle}>
             <SearchLayout keyword={keyword} setKeyword={setKeyword} hashTagData={HASH_TAGS_DUMMY} />
-            <div css={s.scrollLayoutStyle}>
-              <TitleContainer
-                title="그룹 채팅방"
-                textButton="전체보기"
-                handleTextButtonClick={() => {
-                  navigate("./group-chat-list");
-                }}
-              >
-                <GroupChatList data={groupChatRoom} handleItemClick={handleItemClick} />
-              </TitleContainer>
-              <TitleContainer
-                title="오프라인 커피챗"
-                textButton="전체보기"
-                handleTextButtonClick={() => {
-                  navigate("./coffee-chat-list");
-                }}
-                css={{ paddingBottom: "5rem" }}
-              >
-                <CoffeeChatList />
-              </TitleContainer>
-            </div>
+            <TitleContainer
+              title="그룹 채팅방"
+              textButton="전체보기"
+              handleTextButtonClick={() => {
+                navigate("./group-chat-list");
+              }}
+            >
+              <GroupChatList data={groupChatRoom} handleItemClick={handleItemClick} />
+            </TitleContainer>
+            <TitleContainer
+              title="오프라인 커피챗"
+              textButton="전체보기"
+              handleTextButtonClick={() => {
+                navigate("./coffee-chat-list");
+              }}
+              css={{ paddingBottom: "5rem" }}
+            >
+              <CoffeeChatList />
+            </TitleContainer>
           </div>
           <TitleContainer
             title="전체 채팅"
             textButton="더보기"
             handleTextButtonClick={() => {
-              navigate("./global-chat");
+              navigate("../global-chat");
             }}
           >
             <GlobalChatPreview />

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -37,25 +37,38 @@ const HomePage = () => {
 
       <div css={s.layoutStyle}>
         <div css={s.leftLayoutStyle}>
-          <SearchLayout keyword={keyword} setKeyword={setKeyword} hashTagData={HASH_TAGS_DUMMY} />
+          <div css={s.leftLayoutStyle}>
+            <SearchLayout keyword={keyword} setKeyword={setKeyword} hashTagData={HASH_TAGS_DUMMY} />
+            <div css={s.scrollLayoutStyle}>
+              <TitleContainer
+                title="그룹 채팅방"
+                textButton="전체보기"
+                handleTextButtonClick={() => {
+                  navigate("./group-chat-list");
+                }}
+              >
+                <GroupChatList data={groupChatRoom} handleItemClick={handleItemClick} />
+              </TitleContainer>
+              <TitleContainer
+                title="오프라인 커피챗"
+                textButton="전체보기"
+                handleTextButtonClick={() => {
+                  navigate("./coffee-chat-list");
+                }}
+                css={{ paddingBottom: "5rem" }}
+              >
+                <CoffeeChatList />
+              </TitleContainer>
+            </div>
+          </div>
           <TitleContainer
-            title="그룹 채팅방"
-            textButton="전체보기"
+            title="전체 채팅"
+            textButton="더보기"
             handleTextButtonClick={() => {
-              navigate("./group-chat-list");
+              navigate("./global-chat");
             }}
           >
-            <GroupChatList data={groupChatRoom} handleItemClick={handleItemClick} />
-          </TitleContainer>
-          <TitleContainer
-            title="오프라인 커피챗"
-            textButton="전체보기"
-            handleTextButtonClick={() => {
-              navigate("./coffee-chat-list");
-            }}
-            css={{ paddingBottom: "5rem" }}
-          >
-            <CoffeeChatList />
+            <GlobalChatPreview />
           </TitleContainer>
         </div>
         <TitleContainer

--- a/src/routers/Router.tsx
+++ b/src/routers/Router.tsx
@@ -46,7 +46,7 @@ export const router = createBrowserRouter([
   },
   {
     path: "/",
-    element: <App />,
+    element: <App iconMenuHeader={true} />,
     children: [
       {
         path: "/mypage",
@@ -87,16 +87,18 @@ export const router = createBrowserRouter([
         path: "/:serverId/home/coffee-chat-list",
         element: <CoffeeChatListPage />,
       },
+    ],
+  },
+  {
+    path: "/:serverId",
+    element: <App iconMenuHeader={true} />,
+    children: [
       {
         path: "/:serverId/group-chat",
-        element: <HomePage />,
+        element: <GroupChatPage />,
       },
       {
         path: "/:serverId/coffee-chat",
-        element: <HomePage />,
-      },
-      {
-        path: "/:serverId/group-chat/chat",
         element: <GroupChatPage />,
       },
       {

--- a/src/stores/useGlobalMenuStore.tsx
+++ b/src/stores/useGlobalMenuStore.tsx
@@ -1,10 +1,10 @@
-import type { GlobalMenuTypes } from "@/constants/serverInfo";
+import type { MenuTypes } from "@/constants/menu";
 import { create } from "zustand";
 
 interface GlobalMenuState {
-  globalMenu: GlobalMenuTypes | null;
+  globalMenu: MenuTypes | null;
   actions: {
-    setGlobalMenu: (menu: GlobalMenuTypes | null) => void;
+    setGlobalMenu: (menu: MenuTypes | null) => void;
     resetGlobalMenu: () => void;
   };
 }

--- a/src/stores/useGlobalServerStore.tsx
+++ b/src/stores/useGlobalServerStore.tsx
@@ -1,0 +1,21 @@
+import type { ServerInfoTypes } from "@/constants/serverInfo";
+import { create } from "zustand";
+
+interface GlobalServerState {
+  globalServer: ServerInfoTypes | null;
+  actions: {
+    setGlobalServer: (menu: ServerInfoTypes | null) => void;
+    resetGlobalServer: () => void;
+  };
+}
+
+const useGlobalServerStore = create<GlobalServerState>((set) => ({
+  globalServer: null,
+  actions: {
+    setGlobalServer: (server) => set({ globalServer: server }),
+    resetGlobalServer: () => set({ globalServer: null }),
+  },
+}));
+
+export const useGlobalServer = () => useGlobalServerStore((state) => state.globalServer);
+export const useGlobalServerAction = () => useGlobalServerStore((state) => state.actions);


### PR DESCRIPTION
## 🎯 관련 이슈

close #67 

<br />

## 🚀 작업 내용

- `iconOnly` prop에 따라 `아이콘만 있는 메뉴 헤더` 띄우도록 조건부 처리
- `아이콘만 있는 메뉴 헤더` 필요한 페이지 적용 (my 관련, 그룹챗, 커피챗)
- 서버 정보 전역변수로 관리

<br />


## 📸 스크린샷
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/57b3e126-39ce-4c3a-a4c7-b18c71cc6c57" />



<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?
- 맨 처음에 `globalServer: null`이라 메뉴 이동이 잘 안 될 수 있는데, 이 문제는 api 붙이면서 서버 기본값 설정되어 해결될 예정
<br />

