### PR TITLE
#72 [FEAT] 서버 헤더 - 내가 속한 서버 조회 API 연결

### DIFF
--- a/src/components/ServerHeader/ServerHeader.tsx
+++ b/src/components/ServerHeader/ServerHeader.tsx
@@ -1,5 +1,6 @@
 import { PlusIcon } from "@/assets/svg";
 import ServerDropdown from "@/components/ServerHeader/components/ServerDropdown/ServerDropdown";
+import { useMyServerList } from "@/components/ServerHeader/hooks/useMyServerList";
 import { GLOBAL_MENUS, type MenuTypes } from "@/constants/menu";
 import { SERVERINFO, type ServerInfoTypes } from "@/constants/serverInfo";
 import ScheduleSideModal from "@/pages/HomePage/components/ScheduleSideModal/ScheduleSideModal";
@@ -18,16 +19,28 @@ const ServerHeader = () => {
   const { setGlobalMenu } = useGlobalMenuAction();
   const { setGlobalServer } = useGlobalServerAction();
 
-  const [myServerIdList] = useState<number[]>([2, 6, 10, 15, 22]);
-  const currentServerInfo = SERVERINFO.find((server) => server.id === myServerIdList[0]);
+  const { data: myServerInfo } = useMyServerList();
+  const simpleMyServerList = myServerInfo?.result.serverList;
 
-  const [currentServer, setCurrentServer] = useState<ServerInfoTypes | undefined>(currentServerInfo);
+  const myServerList = simpleMyServerList?.map((server) => {
+    const serverInfo = SERVERINFO.find((item) => item.id === server.id);
+    return {
+      id: server.id,
+      title: server.title,
+      icon: serverInfo?.icon, // 아이콘을 포함
+    };
+  });
+
+  console.log("myServerList: ", myServerList);
+
+  const [currentServer, setCurrentServer] = useState<ServerInfoTypes | undefined>();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [isScheduleVisible, setIsScheduleVisible] = useState(false);
   const [hoveredGlobalMenuId, setHoveredGlobalMenuId] = useState<string | null>(null);
   const [previousMenu, setPreviousMenu] = useState<MenuTypes | null>(globalMenu);
 
-  const myServerSet = new Set(myServerIdList);
+  const myServerSet = new Set(myServerList?.map((server) => server.id));
+
   const exceptCurrentServer = currentServer
     ? SERVERINFO.filter((server) => myServerSet.has(server.id) && server.id !== currentServer.id)
     : [];

--- a/src/components/ServerHeader/ServerHeader.tsx
+++ b/src/components/ServerHeader/ServerHeader.tsx
@@ -1,11 +1,11 @@
-import { PlusIcon, RotateLogoIcon } from "@/assets/svg";
+import { HomeIcon, PlusIcon } from "@/assets/svg";
 import ServerDropdown from "@/components/ServerHeader/components/ServerDropdown/ServerDropdown";
 import { useMyServerList } from "@/components/ServerHeader/hooks/useServerList";
 import { GLOBAL_MENUS, type MenuTypes } from "@/constants/menu";
 import { SERVERINFO, type ServerInfoTypes } from "@/constants/serverInfo";
 import ScheduleSideModal from "@/pages/HomePage/components/ScheduleSideModal/ScheduleSideModal";
 import { useGlobalMenu, useGlobalMenuAction } from "@/stores/useGlobalMenuStore";
-import { useGlobalServer, useGlobalServerAction } from "@/stores/useGlobalServerStore";
+import { useGlobalServerAction } from "@/stores/useGlobalServerStore";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import * as s from "./ServerHeader.styles";
@@ -14,7 +14,6 @@ const ServerHeader = () => {
   const navigate = useNavigate();
 
   const globalMenu = useGlobalMenu();
-  const globalServer = useGlobalServer();
 
   const { setGlobalMenu } = useGlobalMenuAction();
   const { setGlobalServer } = useGlobalServerAction();
@@ -37,7 +36,7 @@ const ServerHeader = () => {
           {
             id: server.id,
             title: server.title,
-            icon: serverInfo?.icon || RotateLogoIcon,
+            icon: serverInfo?.icon || HomeIcon,
           },
         ];
       })
@@ -67,9 +66,7 @@ const ServerHeader = () => {
   };
 
   useEffect(() => {
-    if (!isScheduleVisible && globalMenu?.id === "schedule") {
-      setGlobalMenu(previousMenu);
-    }
+    !isScheduleVisible && globalMenu?.id === "schedule" && setGlobalMenu(previousMenu);
   }, [isScheduleVisible, globalMenu, previousMenu, setGlobalMenu]);
 
   return (

--- a/src/components/ServerHeader/ServerHeader.tsx
+++ b/src/components/ServerHeader/ServerHeader.tsx
@@ -1,6 +1,6 @@
 import { PlusIcon, RotateLogoIcon } from "@/assets/svg";
 import ServerDropdown from "@/components/ServerHeader/components/ServerDropdown/ServerDropdown";
-import { useAllServerList, useMyServerList } from "@/components/ServerHeader/hooks/useServerList";
+import { useMyServerList } from "@/components/ServerHeader/hooks/useServerList";
 import { GLOBAL_MENUS, type MenuTypes } from "@/constants/menu";
 import { SERVERINFO, type ServerInfoTypes } from "@/constants/serverInfo";
 import ScheduleSideModal from "@/pages/HomePage/components/ScheduleSideModal/ScheduleSideModal";
@@ -19,15 +19,14 @@ const ServerHeader = () => {
   const { setGlobalMenu } = useGlobalMenuAction();
   const { setGlobalServer } = useGlobalServerAction();
 
-  const { data: myServerInfo } = useMyServerList();
-  const { data: allServerInfo } = useAllServerList();
-  console.log(allServerInfo);
-  const myServerIdTitleList = myServerInfo?.result.serverList || [];
-
+  const [currentServer, setCurrentServer] = useState<ServerInfoTypes | undefined>(undefined);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [isScheduleVisible, setIsScheduleVisible] = useState(false);
   const [hoveredGlobalMenuId, setHoveredGlobalMenuId] = useState<string | null>(null);
   const [previousMenu, setPreviousMenu] = useState<MenuTypes | null>(globalMenu);
+
+  const { data: myServerInfo } = useMyServerList();
+  const myServerIdTitleList = myServerInfo?.result.serverList || [];
 
   const myServerList = Array.from(
     new Map(
@@ -45,7 +44,9 @@ const ServerHeader = () => {
     ).values()
   );
 
-  const [currentServer, setCurrentServer] = useState<ServerInfoTypes | null>(null);
+  const exceptCurrentServer = currentServer
+    ? myServerList.filter((server) => server.id !== currentServer.id)
+    : myServerList;
 
   useEffect(() => {
     if (myServerList.length > 0 && !currentServer) {
@@ -53,15 +54,6 @@ const ServerHeader = () => {
       setGlobalServer(myServerList[0]);
     }
   }, [myServerList, currentServer, setGlobalServer]);
-
-  console.log("myServerList: ", myServerList);
-  console.log("currentServer: ", currentServer);
-
-  const exceptCurrentServer = currentServer
-    ? myServerList.filter((server) => server.id !== currentServer.id)
-    : myServerList; // currentServer가 없으면 전체 리스트 반환
-
-  console.log("exceptCurrentServer", exceptCurrentServer);
 
   const handleGlobalMenuClick = (menu: MenuTypes) => {
     setPreviousMenu(globalMenu);

--- a/src/components/ServerHeader/apis/server.ts
+++ b/src/components/ServerHeader/apis/server.ts
@@ -1,4 +1,5 @@
 import { tokenInstance } from "@/apis/instance";
+import type { ServerResponseTypes } from "@/components/ServerHeader/types/serverTypes";
 import type { HomeResponseTypes } from "@/pages/HomePage/types/homeDataTypes";
 
 // [GET] Find All Servers
@@ -8,6 +9,18 @@ export const fetchAllServers = async () => {
     return response;
   } catch (error) {
     console.error("전체 서버 받아오기 실패:", error);
+  }
+};
+
+// [GET] Find My Servers
+export const fetchMyServers = async (): Promise<ServerResponseTypes> => {
+  try {
+    const response = await tokenInstance("api/v1/servers?scope=joined").json();
+    return response as ServerResponseTypes; // 응답을 ServerResponseTypes로 명시적으로 변환
+  } catch (error) {
+    console.error("내 서버 받아오기 실패:", error);
+    // 에러 발생 시 명확한 처리 (reject를 통해 에러를 던질 수 있음)
+    return Promise.reject(error);
   }
 };
 

--- a/src/components/ServerHeader/apis/server.ts
+++ b/src/components/ServerHeader/apis/server.ts
@@ -2,7 +2,6 @@ import { tokenInstance } from "@/apis/instance";
 import type { ServerResponseTypes } from "@/components/ServerHeader/types/serverTypes";
 import type { HomeResponseTypes } from "@/pages/HomePage/types/homeDataTypes";
 
-// [GET] Find All Servers
 export const fetchAllServers = async () => {
   try {
     const response = await tokenInstance("api/v1/servers").json();
@@ -12,29 +11,25 @@ export const fetchAllServers = async () => {
   }
 };
 
-// [GET] Find My Servers
 export const fetchMyServers = async (): Promise<ServerResponseTypes> => {
   try {
     const response = await tokenInstance("api/v1/servers?scope=joined").json();
-    return response as ServerResponseTypes; // 응답을 ServerResponseTypes로 명시적으로 변환
+    return response as ServerResponseTypes;
   } catch (error) {
     console.error("내 서버 받아오기 실패:", error);
-    // 에러 발생 시 명확한 처리 (reject를 통해 에러를 던질 수 있음)
     return Promise.reject(error);
   }
 };
 
-// [GET] Server Home
 export const fetchServerHome = async (serverId: number) => {
   try {
     const response = await tokenInstance(`api/v1/servers/${serverId}`).json<HomeResponseTypes>();
     return response.result;
   } catch (error) {
-    console.error(`홈 서버 정보 받아오기 실패 (${serverId}번 서버):`, error);
+    console.error(`홈 정보 받아오기 실패 (${serverId}번 서버):`, error);
   }
 };
 
-// [POST] Enter Server
 export const enterServer = async (serverId: number) => {
   try {
     const response = await tokenInstance.post(`api/v1/servers/${serverId}`).json();
@@ -44,7 +39,6 @@ export const enterServer = async (serverId: number) => {
   }
 };
 
-// [DELETE] Exit Server
 export const exitServer = async (serverId: number) => {
   try {
     const response = await tokenInstance.delete(`api/v1/servers/${serverId}`).json();

--- a/src/components/ServerHeader/hooks/useMyServerList.ts
+++ b/src/components/ServerHeader/hooks/useMyServerList.ts
@@ -1,0 +1,13 @@
+import { fetchMyServers } from "@/components/ServerHeader/apis/server";
+import type { ServerResponseTypes } from "@/components/ServerHeader/types/serverTypes";
+import { useQuery } from "@tanstack/react-query";
+
+export const useMyServerList = () => {
+  return useQuery<ServerResponseTypes>({
+    queryKey: ["myServerInfo"],
+    queryFn: fetchMyServers,
+    staleTime: 1000 * 60 * 10,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+};

--- a/src/components/ServerHeader/hooks/useServerList.ts
+++ b/src/components/ServerHeader/hooks/useServerList.ts
@@ -1,6 +1,16 @@
-import { fetchMyServers } from "@/components/ServerHeader/apis/server";
+import { fetchAllServers, fetchMyServers } from "@/components/ServerHeader/apis/server";
 import type { ServerResponseTypes } from "@/components/ServerHeader/types/serverTypes";
 import { useQuery } from "@tanstack/react-query";
+
+export const useAllServerList = () => {
+  return useQuery<ServerResponseTypes>({
+    queryKey: ["allServerInfo"],
+    queryFn: fetchAllServers as () => Promise<ServerResponseTypes>,
+    staleTime: 1000 * 60 * 10,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+};
 
 export const useMyServerList = () => {
   return useQuery<ServerResponseTypes>({

--- a/src/components/ServerHeader/hooks/useServerList.ts
+++ b/src/components/ServerHeader/hooks/useServerList.ts
@@ -7,7 +7,6 @@ export const useAllServerList = () => {
     queryKey: ["allServerInfo"],
     queryFn: fetchAllServers as () => Promise<ServerResponseTypes>,
     staleTime: 1000 * 60 * 10,
-    refetchOnMount: false,
     refetchOnWindowFocus: false,
   });
 };
@@ -15,9 +14,8 @@ export const useAllServerList = () => {
 export const useMyServerList = () => {
   return useQuery<ServerResponseTypes>({
     queryKey: ["myServerInfo"],
-    queryFn: fetchMyServers,
+    queryFn: fetchMyServers as () => Promise<ServerResponseTypes>,
     staleTime: 1000 * 60 * 10,
-    refetchOnMount: false,
     refetchOnWindowFocus: false,
   });
 };

--- a/src/components/ServerHeader/types/serverTypes.ts
+++ b/src/components/ServerHeader/types/serverTypes.ts
@@ -1,0 +1,14 @@
+interface Server {
+  id: number;
+  title: string;
+}
+
+export interface ServerResponseTypes {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    count: number;
+    serverList: Server[];
+  };
+}

--- a/src/components/ServerHeader/types/serverTypes.ts
+++ b/src/components/ServerHeader/types/serverTypes.ts
@@ -1,4 +1,4 @@
-interface Server {
+export interface ServerTypes {
   id: number;
   title: string;
 }
@@ -9,6 +9,6 @@ export interface ServerResponseTypes {
   message: string;
   result: {
     count: number;
-    serverList: Server[];
+    serverList: ServerTypes[];
   };
 }

--- a/src/constants/serverInfo.ts
+++ b/src/constants/serverInfo.ts
@@ -10,33 +10,32 @@ import {
 
 export type ServerInfoTypes = {
   id: number;
-  name: string;
+  title: string;
   icon: React.ElementType<SVGProps<SVGSVGElement>>;
 };
-
 export const SERVERINFO: ServerInfoTypes[] = [
-  { id: 0, name: "광고/마케팅", icon: HomeIcon },
-  { id: 1, name: "금융/보험/핀테크", icon: HomeIcon },
-  { id: 2, name: "모빌리티/교통", icon: MobilityServerIcon },
-  { id: 3, name: "부동산/건설", icon: HomeIcon },
-  { id: 4, name: "AI/딥테크/블록체인", icon: HomeIcon },
-  { id: 5, name: "여행/레저", icon: HomeIcon },
-  { id: 6, name: "인사/법률", icon: HrLawServerIcon },
-  { id: 7, name: "커머스/비즈니스", icon: HomeIcon },
-  { id: 8, name: "통신/데이터", icon: HomeIcon },
-  { id: 9, name: "푸드/농업", icon: HomeIcon },
-  { id: 10, name: "홈리빙/펫", icon: HomeLivingServerIcon },
-  { id: 11, name: "스포츠", icon: HomeIcon },
-  { id: 12, name: "교육", icon: HomeIcon },
-  { id: 13, name: "게임", icon: HomeIcon },
-  { id: 14, name: "물류", icon: HomeIcon },
-  { id: 15, name: "뷰티/화장품", icon: BeautyServerIcon },
-  { id: 16, name: "소셜미디어/커뮤니티", icon: HomeIcon },
-  { id: 17, name: "유아/출산", icon: HomeIcon },
-  { id: 18, name: "제조/하드웨어", icon: HomeIcon },
-  { id: 19, name: "콘텐츠/예술", icon: HomeIcon },
-  { id: 20, name: "패션", icon: HomeIcon },
-  { id: 21, name: "환경/에너지", icon: HomeIcon },
-  { id: 22, name: "헬스케어/바이오", icon: HealthServerIcon },
-  { id: 23, name: "기타", icon: HomeIcon },
+  { id: 1, title: "광고/마케팅", icon: HomeIcon },
+  { id: 2, title: "부동산/건설", icon: HomeIcon },
+  { id: 3, title: "인사/법률", icon: HrLawServerIcon },
+  { id: 4, title: "푸드/농업", icon: HomeIcon },
+  { id: 5, title: "교육", icon: HomeIcon },
+  { id: 6, title: "뷰티/화장품", icon: BeautyServerIcon },
+  { id: 7, title: "제조/하드웨어", icon: HomeIcon },
+  { id: 8, title: "환경/에너지", icon: HomeIcon },
+  { id: 9, title: "금융/보험/핀테크", icon: HomeIcon },
+  { id: 10, title: "AI/딥테크/블록체인", icon: HomeIcon },
+  { id: 11, title: "커머스/비즈니스", icon: HomeIcon },
+  { id: 12, title: "홈리빙/펫", icon: HomeLivingServerIcon },
+  { id: 13, title: "게임", icon: HomeIcon },
+  { id: 14, title: "소셜미디어/커뮤니티", icon: HomeIcon },
+  { id: 15, title: "콘텐츠/예술", icon: HomeIcon },
+  { id: 16, title: "헬스케어/바이오", icon: HealthServerIcon },
+  { id: 17, title: "모빌리티/교통", icon: MobilityServerIcon },
+  { id: 18, title: "여행/레저", icon: HomeIcon },
+  { id: 19, title: "통신/데이터", icon: HomeIcon },
+  { id: 20, title: "스포츠", icon: HomeIcon },
+  { id: 21, title: "물류", icon: HomeIcon },
+  { id: 22, title: "유아/출산", icon: HomeIcon },
+  { id: 23, title: "패션", icon: HomeIcon },
 ];
+

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -8,7 +8,6 @@ import { useGlobalServer } from "@/stores/useGlobalServerStore";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import * as s from "./HomePage.styles";
-
 const HomePage = () => {
   const navigate = useNavigate();
   const globalServer = useGlobalServer();
@@ -18,19 +17,18 @@ const HomePage = () => {
   const [selectedItemId, setSelectedItemId] = useState<string | undefined>(undefined);
 
   const serverId = globalServer?.id;
-  const { title, currentUsers, maxUsers } = CHAT_ROOM_DETAIL_DUMMY;
-
-  const handleItemClick = (id: string) => {
-    setSelectedItemId(id);
-    setIsVisible(true);
-  };
-
   const { data: homeData, isLoading } = useHomeData(serverId);
 
   if (isLoading) return <div>로딩 중...</div>;
   if (!homeData) return <div>데이터 없음</div>;
 
+  const { title, currentUsers, maxUsers } = CHAT_ROOM_DETAIL_DUMMY;
   const { hashTagList, groupChatRoom, meetingChatRoom, notice } = homeData;
+
+  const handleItemClick = (id: string) => {
+    setSelectedItemId(id);
+    setIsVisible(true);
+  };
 
   return (
     <>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -4,7 +4,7 @@ import CoffeeChatList from "@/pages/CoffeeChatListPage/components/CoffeeChatList
 import GroupChatList from "@/pages/GroupChatListPage/components/GroupChatList/GroupChatList";
 import GlobalChatPreview from "@/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview";
 import { useHomeData } from "@/pages/HomePage/hooks/useHomeData";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import * as s from "./HomePage.styles";
 
@@ -25,7 +25,9 @@ const HomePage = () => {
     setIsVisible(true);
   };
 
-  const { data: homeData, isLoading } = useHomeData(serverId);
+  // const { data: homeData, isLoading } = useHomeData(serverId);
+  const { data: homeData, isLoading } = useHomeData(useMemo(() => serverId, [serverId]));
+
 
   if (isLoading) return <div>로딩 중...</div>;
   if (!homeData) return <div>데이터 없음</div>;

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -4,30 +4,28 @@ import CoffeeChatList from "@/pages/CoffeeChatListPage/components/CoffeeChatList
 import GroupChatList from "@/pages/GroupChatListPage/components/GroupChatList/GroupChatList";
 import GlobalChatPreview from "@/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview";
 import { useHomeData } from "@/pages/HomePage/hooks/useHomeData";
-import { useMemo, useState } from "react";
+import { useGlobalServer } from "@/stores/useGlobalServerStore";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import * as s from "./HomePage.styles";
 
 const HomePage = () => {
   const navigate = useNavigate();
-
-  const serverId = 1; // 임시 id
+  const globalServer = useGlobalServer();
 
   const [keyword, setKeyword] = useState("");
   const [isVisible, setIsVisible] = useState(false);
-
-  const { title, currentUsers, maxUsers } = CHAT_ROOM_DETAIL_DUMMY;
-
   const [selectedItemId, setSelectedItemId] = useState<string | undefined>(undefined);
+
+  const serverId = globalServer?.id;
+  const { title, currentUsers, maxUsers } = CHAT_ROOM_DETAIL_DUMMY;
 
   const handleItemClick = (id: string) => {
     setSelectedItemId(id);
     setIsVisible(true);
   };
 
-  // const { data: homeData, isLoading } = useHomeData(serverId);
-  const { data: homeData, isLoading } = useHomeData(useMemo(() => serverId, [serverId]));
-
+  const { data: homeData, isLoading } = useHomeData(serverId);
 
   if (isLoading) return <div>로딩 중...</div>;
   if (!homeData) return <div>데이터 없음</div>;

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -23,7 +23,7 @@ const HomePage = () => {
   if (!homeData) return <div>데이터 없음</div>;
 
   const { title, currentUsers, maxUsers } = CHAT_ROOM_DETAIL_DUMMY;
-  const { hashTagList, groupChatRoom, meetingChatRoom, notice } = homeData;
+  const { hashTagList, groupChatRoom, meetingChatRoom, notice, chat } = homeData;
 
   const handleItemClick = (id: string) => {
     setSelectedItemId(id);
@@ -68,9 +68,9 @@ const HomePage = () => {
           handleTextButtonClick={() => {
             navigate("../global-chat");
           }}
-          css={{ paddingTop: "12.3rem" }}
+          css={{ paddingTop: "10rem" }}
         >
-          <GlobalChatPreview />
+          <GlobalChatPreview chat={chat} notice={notice}/>
         </TitleContainer>
       </div>
     </>

--- a/src/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview.styles.ts
+++ b/src/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview.styles.ts
@@ -61,6 +61,7 @@ export const chatStyle = css`
   padding: 1.6rem 1.4rem;
 
   width: 28rem;
+  min-height: 26.4rem;
 
   border-radius: 1rem;
   background-color: ${theme.color.dark3};

--- a/src/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview.tsx
+++ b/src/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview.tsx
@@ -1,40 +1,29 @@
 import { PinIcon } from "@/assets/svg";
 import { Button } from "@/components";
+import type { HomeDataTypes } from "@/pages/HomePage/types/homeDataTypes";
 import * as s from "./GlobalChatPreview.styles";
 
-const chatDummy = [
-  {
-    id: 1,
-    name: "김준희",
-    message: "실시간 채팅ㅋㅋㅋㅋㅋㅋ으하하 무슨 말을 적어볼까나 실시간 채팅ㅋㅋㅋㅋㅋㅋ으하하 무슨 말을 적어볼까나",
-  },
-  { id: 2, name: "남다은", message: "실시간 채팅ㅋㅋㅋㅋㅋㅋ" },
-  { id: 3, name: "이민호", message: "안녕하세요! 반갑습니다." },
-  { id: 4, name: "박지성", message: "오늘 날씨가 좋네요." },
-  { id: 5, name: "최수영", message: "다들 점심 뭐 드셨나요?" },
-  { id: 6, name: "김태희", message: "프로젝트 진행 상황 공유합니다." },
-  { id: 7, name: "정우성", message: "주말에 뭐 하시나요?" },
-  { id: 8, name: "한지민", message: "좋은 아침입니다!" },
-  { id: 9, name: "송중기", message: "회의는 언제 시작하나요?" },
-  { id: 10, name: "전지현", message: "다음 주 일정 확인 부탁드립니다." },
-];
+interface GlobalChatPreviewProps {
+  notice: HomeDataTypes["notice"];
+  chat: HomeDataTypes["chat"];
+}
 
-const GlobalChatPreview = () => {
+const GlobalChatPreview = ({ notice, chat }: GlobalChatPreviewProps) => {
   return (
     <div css={s.layoutStyle}>
       <div css={s.noticeStyle}>
         <PinIcon width={10} height={13} />
         <p>[공지필독]</p>
-        <p>처음 오신 분들은 공지를 꼭 읽어주세요. 왜냐하면 이 문장은 긴 문장이기 때문입니다.</p>
+        <p>{notice.pageInfo.totalElements > 0 ? notice.noticeList[0].title : "공지사항이 없습니다."}</p>
       </div>
       <div css={s.chatStyle}>
-        {chatDummy.slice(0, 6).map((chat) => {
+        {chat.chatList.slice(0, 6).map((chat) => {
           return (
             <div css={s.chatBarStyle} key={chat.id}>
               <Button variant="tertiary" size="medium">
-                {chat.name}
+                {chat.user.nickname}
               </Button>
-              <p>{chat.message}</p>
+              <p>{chat.content}</p>
             </div>
           );
         })}

--- a/src/pages/HomePage/hooks/useHomeData.ts
+++ b/src/pages/HomePage/hooks/useHomeData.ts
@@ -1,11 +1,15 @@
 import { fetchServerHome } from "@/components/ServerHeader/apis/server";
 import { useQuery } from "@tanstack/react-query";
 
-export const useHomeData = (serverId: number) => {
+export const useHomeData = (serverId?: number) => {
   return useQuery({
     queryKey: ["serverHome", serverId],
-    queryFn: () => fetchServerHome(serverId),
-    enabled: !!serverId,
-    staleTime: 10 * 60 * 1000
+    queryFn: async () => {
+      if (serverId === undefined) {
+        return Promise.reject(new Error("serverId is undefined"));
+      }
+      return fetchServerHome(serverId);
+    },
+    staleTime: 10 * 60 * 1000,
   });
 };

--- a/src/pages/HomePage/hooks/useHomeData.ts
+++ b/src/pages/HomePage/hooks/useHomeData.ts
@@ -6,5 +6,6 @@ export const useHomeData = (serverId: number) => {
     queryKey: ["serverHome", serverId],
     queryFn: () => fetchServerHome(serverId),
     enabled: !!serverId,
+    staleTime: 10 * 60 * 1000
   });
 };

--- a/src/pages/OnboardingPage/components/KakaoLogin/KakaoLogin.tsx
+++ b/src/pages/OnboardingPage/components/KakaoLogin/KakaoLogin.tsx
@@ -1,5 +1,7 @@
+import { fetchMyServers } from "@/components/ServerHeader/apis/server";
+import { PATH } from "@/constants/path";
 import { useKakaoLogin } from "@/pages/OnboardingPage/hooks/useKakaoLogin";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 const KakaoLogin = () => {
@@ -8,14 +10,29 @@ const KakaoLogin = () => {
 
   const { data, isSuccess } = useKakaoLogin(code);
 
+  const redirectToFirstServer = useCallback(async () => {
+    try {
+      const myServers = await fetchMyServers();
+
+      if (myServers?.result.count > 0) {
+        const firstServerId = myServers.result.serverList[0].id;
+        navigate(PATH.HOME.replace(":serverId", String(firstServerId)));
+      } else {
+        navigate(PATH.SIGNUP);
+      }
+    } catch (error) {
+      navigate(PATH.SIGNUP);
+    }
+  }, [navigate]);
+
   useEffect(() => {
     if (isSuccess && data) {
       localStorage.setItem("accessToken", data.result.accessToken);
       localStorage.setItem("refreshToken", data.result.refreshToken);
 
-      navigate("/signup");
+      redirectToFirstServer();
     }
-  }, [data, isSuccess, navigate]);
+  }, [data, isSuccess, redirectToFirstServer]);
 
   return <div>로딩 중</div>;
 };


### PR DESCRIPTION
## 🎯 관련 이슈

close #72 

<br />

## 🚀 작업 내용

- 서버 헤더에 내가 속한 서버 조회 API 연결하기
- 로그인 시, 계정 이미 있을 경우, 내가 속한 서버 중 첫 번째 `serverId/home`으로 바로 navigate 되도록
- 홈 화면에 공지, 전체 채팅 api에서 받아온 데이터 띄우기

<br />


## 📸 스크린샷

https://github.com/user-attachments/assets/5ed9aa7d-8d1e-4f56-bcf1-e6f27a75e09e

<img width="1259" alt="image" src="https://github.com/user-attachments/assets/a6d3738c-8404-4bc4-b63d-efb4eeb6e16d" />



<br />


## 🔎 발견된 장애가 있었나요?

- 현재 서버 추가할 때 post api 두 번 호출되면 서버 리스트에 같은 서버가 2번 등록되는 문제가 있습니다.
- 두 번 등록된 서버에서는 상세 데이터가 안 받아와지니 참고바랍니다.
- 해당 문제 현재 백에서 수정 중입니다.

<br />

 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
