### PR TITLE
#71 [FEAT] 그룹챗 생성 api 연결

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -16,3 +16,10 @@ export const tokenInstance = ky.create({
     Authorization: `Bearer ${accessToken}`,
   },
 });
+
+export const formDataInstance = ky.create({
+  prefixUrl: import.meta.env.VITE_BASE_URL,
+  headers: {
+    Authorization: `Bearer ${accessToken}`,
+  },
+});

--- a/src/pages/GroupChatListPage/GroupChatListPage.tsx
+++ b/src/pages/GroupChatListPage/GroupChatListPage.tsx
@@ -15,11 +15,7 @@ const GroupChatListPage = () => {
     <div css={s.layoutStyle}>
       <AddGroupChatModal isVisible={isVisible} setIsVisible={setIsVisible} />
       <AddButton setIsModalVisible={setIsVisible} />
-      <SearchLayout
-        keyword={keyword}
-        setKeyword={setKeyword}
-        hashTagData={HASH_TAGS_DUMMY}
-      />
+      <SearchLayout keyword={keyword} setKeyword={setKeyword} hashTagData={HASH_TAGS_DUMMY} />
 
       <TitleContainer
         title="그룹 채팅방"

--- a/src/pages/GroupChatListPage/apis/addGroupChat.ts
+++ b/src/pages/GroupChatListPage/apis/addGroupChat.ts
@@ -1,0 +1,13 @@
+import { formDataInstance } from "@/apis/instance";
+
+// [POST] 그룹챗 생성
+export const createGroupChat = async (serverId: number, formData: FormData) => {
+  try {
+    const response = await formDataInstance.post(`api/v1/servers/${serverId}/groups`, {
+      body: formData,
+    });
+    return response.json();
+  } catch (error) {
+    console.error("그룹챗 생성 실패:", error);
+  }
+};

--- a/src/pages/GroupChatListPage/components/AddGroupChatModal/AddGroupChatModal.tsx
+++ b/src/pages/GroupChatListPage/components/AddGroupChatModal/AddGroupChatModal.tsx
@@ -1,11 +1,11 @@
 import { Button, FileUploadBox, HashtagInput, Input, SideModal, TagChip, Textarea } from "@/components";
 import { useFileUpload } from "@/components/FileUploadBox/hooks/useFileUpload";
-import { useHashtag } from "@/components/TagChip/hooks/useHashtag";
 import type { SideModalProps } from "@/components/SideModal/types/sideModalTypes";
-
+import { useHashtag } from "@/components/TagChip/hooks/useHashtag";
 import { SUPPORTING_TEXT } from "@/constants/supportingText";
 import { TEXT_MAX_LENGTH } from "@/pages/GroupChatListPage/constants/textMaxLength";
 import { useAddGroupChat } from "@/pages/GroupChatListPage/hooks/useAddGroupChat";
+import { useGlobalServer } from "@/stores/useGlobalServerStore";
 import { useState } from "react";
 import * as s from "./AddGroupChatModal.styles";
 
@@ -16,13 +16,15 @@ interface AddGroupChatTypes {
 }
 
 const AddGroupChatModal = ({ isVisible, setIsVisible }: SideModalProps) => {
+  const globalServer = useGlobalServer();
+
   const [request, setRequest] = useState<AddGroupChatTypes>({
     title: "",
     content: "",
     hashTags: [],
   });
 
-  const { handleInputChange, handleFocus, handleBlur, isFieldError } = useAddGroupChat({
+  const { handleInputChange, handleFocus, handleBlur, isFieldError, uploadGroupChat } = useAddGroupChat({
     request,
     setRequest,
     maxLengths: TEXT_MAX_LENGTH,
@@ -34,9 +36,22 @@ const AddGroupChatModal = ({ isVisible, setIsVisible }: SideModalProps) => {
 
   const isButtonDisabled = isFieldError("title", request.title);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setIsVisible(false);
+    try {
+      if (!globalServer) {
+        console.log(globalServer);
+        console.error("서버 정보가 없습니다.");
+        return;
+      }
+      uploadGroupChat({
+        serverId: globalServer.id,
+        file: image || null,
+      });
+      setIsVisible(false);
+    } catch (error) {
+      console.error("그룹챗 생성 실패:", error);
+    }
   };
 
   return (

--- a/src/pages/GroupChatListPage/components/AddGroupChatModal/AddGroupChatModal.tsx
+++ b/src/pages/GroupChatListPage/components/AddGroupChatModal/AddGroupChatModal.tsx
@@ -56,7 +56,15 @@ const AddGroupChatModal = ({ isVisible, setIsVisible }: SideModalProps) => {
 
   return (
     <SideModal title="그룹 채팅방 개설하기" isVisible={isVisible} setIsVisible={setIsVisible}>
-      <form css={s.modalContentStyle} onSubmit={handleSubmit}>
+      <form
+        css={s.modalContentStyle}
+        onSubmit={handleSubmit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && (e.target as HTMLElement).tagName !== "TEXTAREA") {
+            e.preventDefault();
+          }
+        }}
+      >
         <ul css={s.contentListStyle}>
           <li css={[s.questionContainer, { maxWidth: "35rem" }]}>
             <label htmlFor="title" css={s.textareaTitleStyle}>
@@ -95,7 +103,7 @@ const AddGroupChatModal = ({ isVisible, setIsVisible }: SideModalProps) => {
             <ul css={s.hashtagListContainer}>
               {request.hashTags.map((hashtag, idx) => (
                 <li key={idx}>
-                  <TagChip content={hashtag} removeHashtag={() => removeHashtag(hashtag)} />
+                  <TagChip id={idx} content={hashtag} removeHashtag={() => removeHashtag(hashtag)} />
                 </li>
               ))}
               {request.hashTags.length < 10 && <HashtagInput addHashtag={addHashtag} />}

--- a/src/pages/GroupChatListPage/components/AddGroupChatModal/AddGroupChatModal.tsx
+++ b/src/pages/GroupChatListPage/components/AddGroupChatModal/AddGroupChatModal.tsx
@@ -17,42 +17,26 @@ interface AddGroupChatTypes {
 
 const AddGroupChatModal = ({ isVisible, setIsVisible }: SideModalProps) => {
   const globalServer = useGlobalServer();
-
   const [request, setRequest] = useState<AddGroupChatTypes>({
     title: "",
     content: "",
     hashTags: [],
   });
 
-  const { handleInputChange, handleFocus, handleBlur, isFieldError, uploadGroupChat } = useAddGroupChat({
-    request,
-    setRequest,
-    maxLengths: TEXT_MAX_LENGTH,
-  });
-
   const { addHashtag, removeHashtag } = useHashtag<AddGroupChatTypes>(request, setRequest);
 
   const { image, fileInputRef, handleFileChange, handleFileDelete, handleFileClick } = useFileUpload();
 
-  const isButtonDisabled = isFieldError("title", request.title);
+  const { handleSubmit, handleInputChange, handleFocus, handleBlur, isFieldError } = useAddGroupChat({
+    request,
+    setRequest,
+    maxLengths: TEXT_MAX_LENGTH,
+    setIsVisible,
+    globalServer,
+    image: image,
+  });
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      if (!globalServer) {
-        console.log(globalServer);
-        console.error("서버 정보가 없습니다.");
-        return;
-      }
-      uploadGroupChat({
-        serverId: globalServer.id,
-        file: image || null,
-      });
-      setIsVisible(false);
-    } catch (error) {
-      console.error("그룹챗 생성 실패:", error);
-    }
-  };
+  const isButtonDisabled = isFieldError("title", request.title);
 
   return (
     <SideModal title="그룹 채팅방 개설하기" isVisible={isVisible} setIsVisible={setIsVisible}>

--- a/src/pages/GroupChatListPage/hooks/useAddGroupChat.ts
+++ b/src/pages/GroupChatListPage/hooks/useAddGroupChat.ts
@@ -1,3 +1,5 @@
+import { createGroupChat } from "@/pages/GroupChatListPage/apis/addGroupChat";
+import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 
 interface AddGroupChatTypes {
@@ -12,14 +14,8 @@ interface UseAddGroupChatProps {
   maxLengths: Record<string, number>;
 }
 
-export const useAddGroupChat = ({
-  request,
-  setRequest,
-  maxLengths,
-}: UseAddGroupChatProps) => {
-  const [focusedField, setFocusedField] = useState<
-    Record<string, { hasBeenFocused: boolean; isFocused: boolean }>
-  >({});
+export const useAddGroupChat = ({ request, setRequest, maxLengths }: UseAddGroupChatProps) => {
+  const [focusedField, setFocusedField] = useState<Record<string, { hasBeenFocused: boolean; isFocused: boolean }>>({});
 
   const handleFocus = (field: string) => {
     setFocusedField((prev) => ({
@@ -49,11 +45,34 @@ export const useAddGroupChat = ({
     }));
   };
 
+  const {
+    mutate: uploadGroupChat,
+    isError,
+    error,
+  } = useMutation({
+    mutationFn: ({ serverId, file }: { serverId: number; file: File | null }) => {
+      const formData = new FormData();
+      formData.append("request", JSON.stringify(request));
+
+      if (file) {
+        const fileType = file.type || "";
+        const fileBlob = new Blob([file], { type: fileType });
+        formData.append("image", fileBlob, file.name);
+      } else {
+        formData.append("image", new Blob([], { type: "" }), "");
+      }
+
+      return createGroupChat(serverId, formData);
+    },
+  });
+
   return {
-    request,
     isFieldError,
     handleInputChange,
     handleFocus,
     handleBlur,
+    uploadGroupChat,
+    isError,
+    error,
   };
 };

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -70,7 +70,7 @@ const HomePage = () => {
           }}
           css={{ paddingTop: "10rem" }}
         >
-          <GlobalChatPreview chat={chat} notice={notice}/>
+          <GlobalChatPreview chat={chat} notice={notice} />
         </TitleContainer>
       </div>
     </>

--- a/src/pages/HomePage/hooks/useHomeData.ts
+++ b/src/pages/HomePage/hooks/useHomeData.ts
@@ -10,6 +10,5 @@ export const useHomeData = (serverId?: number) => {
       }
       return fetchServerHome(serverId);
     },
-    staleTime: 10 * 60 * 1000,
   });
 };


### PR DESCRIPTION
## 🎯 관련 이슈

close #71 

<br />

## 🚀 작업 내용

- 그룹챗 생성 api 연결
  - instance.ts에 formDataInstance 추가 (content-type이 formData인 경우 사용)
  - request는 `content-type: application/json` 따로 지정하지 않아도 되도록 백에서 수정
  - 이미지 없을 경우 formData.append 아예 하지 않아도 되도록 백에서 수정
  - 이미지 있을 경우 blob 사용해서 fileType까지 명시해서 넣기

- 디테일 수정
  - 그룹챗 생성 모달에서 enter 눌렀을 때 닫히는 거 prevent 설정
  - 그룹챗 생성 시 HomePage에 반영되도록 homeData에 대한 staleTime 삭제
  - handleSubmit 함수 훅 내부에서 관리하도록 분리
 
<br />


## 📸 스크린샷
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/aa0ceabe-db44-42b9-89f2-e157828388f2" />

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/8a6d1647-acba-4441-acc8-853b9d3cd89b" />



<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
