### PR TITLE
#96 [FEAT] 그룹챗/커피챗 입장 및 퇴장 API 연결

### DIFF
--- a/src/components/DetailModal/DetailModal.tsx
+++ b/src/components/DetailModal/DetailModal.tsx
@@ -4,25 +4,18 @@ import DetailMeta from "@/components/DetailModal/components/DetailMeta/DetailMet
 import DetailUserInfo from "@/components/DetailModal/components/DetailUserInfo/DetailUserInfo";
 import HamburgerMenu from "@/components/DetailModal/components/HamburgerMenu/HamburgerMenu";
 import type { ChatRoomTypes } from "@/components/DetailModal/types/chatRoomTypes";
-import type { SideModalProps } from "@/components/SideModal/types/sideModalTypes";
 import { useState } from "react";
 import * as s from "./DetailModal.styles";
 
-interface DetailModalProps extends SideModalProps {
+interface DetailModalProps {
   data: ChatRoomTypes;
-  serverId: number ;
+  serverId: number;
   selectedItemId: number;
   isCoffeeChat?: boolean;
+  setIsVisible: (isVisible: boolean) => void;
 }
 
-const DetailModal = ({
-  data,
-  serverId,
-  selectedItemId,
-  isCoffeeChat = false,
-  isVisible,
-  setIsVisible,
-}: DetailModalProps) => {
+const DetailModal = ({ data, serverId, selectedItemId, isCoffeeChat = false, setIsVisible }: DetailModalProps) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const chatRoomType = isCoffeeChat ? "meetings" : "groups";
 
@@ -30,7 +23,7 @@ const DetailModal = ({
     <SideModal
       modalStyle={{ width: "100%", maxWidth: "70rem" }}
       title={data.title}
-      isVisible={isVisible}
+      isVisible={true}
       setIsVisible={setIsVisible}
       extraButton={
         <HamburgerMenu

--- a/src/components/DetailModal/DetailModal.tsx
+++ b/src/components/DetailModal/DetailModal.tsx
@@ -10,11 +10,21 @@ import * as s from "./DetailModal.styles";
 
 interface DetailModalProps extends SideModalProps {
   data: ChatRoomTypes;
+  serverId: number ;
+  selectedItemId: number;
   isCoffeeChat?: boolean;
 }
 
-const DetailModal = ({ data, isCoffeeChat = false, isVisible, setIsVisible }: DetailModalProps) => {
+const DetailModal = ({
+  data,
+  serverId,
+  selectedItemId,
+  isCoffeeChat = false,
+  isVisible,
+  setIsVisible,
+}: DetailModalProps) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const chatRoomType = isCoffeeChat ? "meetings" : "groups";
 
   return (
     <SideModal
@@ -22,7 +32,15 @@ const DetailModal = ({ data, isCoffeeChat = false, isVisible, setIsVisible }: De
       title={data.title}
       isVisible={isVisible}
       setIsVisible={setIsVisible}
-      extraButton={<HamburgerMenu isVisible={isMenuOpen} setIsVisible={setIsMenuOpen} />}
+      extraButton={
+        <HamburgerMenu
+          serverId={serverId}
+          chatRoomType={chatRoomType}
+          selectedItemId={selectedItemId}
+          isVisible={isMenuOpen}
+          setIsVisible={setIsMenuOpen}
+        />
+      }
       {...(isCoffeeChat ? { currentUsers: data.currentCount, maxUsers: data.maxCount } : {})}
     >
       <div css={s.contentStyle}>

--- a/src/components/DetailModal/apis/enterChatRoom.ts
+++ b/src/components/DetailModal/apis/enterChatRoom.ts
@@ -1,0 +1,10 @@
+import { tokenInstance } from "@/apis/instance";
+
+export const enterChatRoom = async (serverId: number, chatRoomType: string, groupId: number) => {
+  try {
+    const response = await tokenInstance.post(`api/v1/servers/${serverId}/${chatRoomType}/${groupId}`).json();
+    return response;
+  } catch (error) {
+    console.error(`${chatRoomType}타입 ${serverId}번 채팅룸 입장 실패:`, error);
+  }
+};

--- a/src/components/DetailModal/apis/exitChatRoom.ts
+++ b/src/components/DetailModal/apis/exitChatRoom.ts
@@ -1,0 +1,10 @@
+import { tokenInstance } from "@/apis/instance";
+
+export const exitChatRoom = async (serverId: number, chatRoomType: string, groupId: number) => {
+  try {
+    const response = await tokenInstance.delete(`api/v1/servers/${serverId}/${chatRoomType}/${groupId}`).json();
+    return response;
+  } catch (error) {
+    console.error(`${chatRoomType}타입 ${serverId}번 채팅룸 퇴장 실패:`, error);
+  }
+};

--- a/src/components/DetailModal/components/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/components/DetailModal/components/HamburgerMenu/HamburgerMenu.tsx
@@ -1,10 +1,33 @@
 import { LeaveIcon } from "@/assets/svg";
+import { useEnterChatRoom } from "@/components/DetailModal/hooks/useEnterChatRoom";
 import type { SideModalProps } from "@/components/SideModal/types/sideModalTypes";
 
-export const HamburgerMenu = ({ isVisible, setIsVisible }: SideModalProps) => {
+interface HamburgerMenuProps extends SideModalProps {
+  serverId: number;
+  chatRoomType: string;
+  selectedItemId: number;
+  isVisible: boolean;
+  setIsVisible: (value: boolean) => void;
+}
+
+export const HamburgerMenu = ({
+  serverId,
+  chatRoomType,
+  selectedItemId,
+  isVisible,
+  setIsVisible,
+}: HamburgerMenuProps) => {
+  const { mutate: enterRoom } = useEnterChatRoom();
+
+  const handleIconClick = () => {
+    console.log("서버 입장 시도");
+    enterRoom({ serverId, chatRoomType, groupId: selectedItemId });
+    setIsVisible(!isVisible);
+  };
+
   return (
     <>
-      <LeaveIcon width={33} height={23} onClick={() => setIsVisible(!isVisible)} />
+      <LeaveIcon width={33} height={23} onClick={handleIconClick} />
       {/* {isVisible && (
         <div css={s.hamburgerLayoutStyle}>
           <div css={s.extendedMenuStyle}>

--- a/src/components/DetailModal/components/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/components/DetailModal/components/HamburgerMenu/HamburgerMenu.tsx
@@ -1,12 +1,11 @@
-import { BookmarkIcon, ChatMenuIcon, HamburgerIcon, LeaveIcon } from "@/assets/svg";
+import { LeaveIcon } from "@/assets/svg";
 import type { SideModalProps } from "@/components/SideModal/types/sideModalTypes";
-import * as s from "./HamburgerMenu.styles";
 
 export const HamburgerMenu = ({ isVisible, setIsVisible }: SideModalProps) => {
   return (
     <>
-      <HamburgerIcon width={33} height={23} onClick={() => setIsVisible(!isVisible)} />
-      {isVisible && (
+      <LeaveIcon width={33} height={23} onClick={() => setIsVisible(!isVisible)} />
+      {/* {isVisible && (
         <div css={s.hamburgerLayoutStyle}>
           <div css={s.extendedMenuStyle}>
             <ChatMenuIcon width={96} height={49} />
@@ -17,7 +16,7 @@ export const HamburgerMenu = ({ isVisible, setIsVisible }: SideModalProps) => {
             </div>
           </div>
         </div>
-      )}
+      )} */}
     </>
   );
 };

--- a/src/components/DetailModal/hooks/useEnterChatRoom.ts
+++ b/src/components/DetailModal/hooks/useEnterChatRoom.ts
@@ -1,0 +1,9 @@
+import { enterChatRoom } from "@/components/DetailModal/apis/enterChatRoom";
+import { useMutation } from "@tanstack/react-query";
+
+export const useEnterChatRoom = () => {
+  return useMutation({
+    mutationFn: ({ serverId, chatRoomType, groupId }: { serverId: number; chatRoomType: string; groupId: number }) =>
+      enterChatRoom(serverId, chatRoomType, groupId),
+  });
+};

--- a/src/components/DetailModal/hooks/useExitChatRoom.ts
+++ b/src/components/DetailModal/hooks/useExitChatRoom.ts
@@ -1,0 +1,9 @@
+import { exitChatRoom } from "@/components/DetailModal/apis/exitChatRoom";
+import { useMutation } from "@tanstack/react-query";
+
+export const useExitChatRoom = () => {
+  return useMutation({
+    mutationFn: ({ serverId, chatRoomType, groupId }: { serverId: number; chatRoomType: string; groupId: number }) =>
+      exitChatRoom(serverId, chatRoomType, groupId),
+  });
+};

--- a/src/pages/GroupChatListPage/components/GroupChatListAll/GroupChatListAll.tsx
+++ b/src/pages/GroupChatListPage/components/GroupChatListAll/GroupChatListAll.tsx
@@ -64,7 +64,6 @@ const GroupChatListAll = () => {
               data={selectedChat}
               serverId={serverId}
               selectedItemId={selectedChat.id}
-              isVisible={true}
               setIsVisible={() => setSelectedId(null)}
             />
           )}

--- a/src/pages/GroupChatListPage/components/GroupChatListAll/GroupChatListAll.tsx
+++ b/src/pages/GroupChatListPage/components/GroupChatListAll/GroupChatListAll.tsx
@@ -60,7 +60,13 @@ const GroupChatListAll = () => {
           </ul>
 
           {selectedChat && (
-            <DetailModal data={selectedChat} isVisible={true} setIsVisible={() => setSelectedId(null)} />
+            <DetailModal
+              data={selectedChat}
+              serverId={serverId}
+              selectedItemId={selectedChat.id}
+              isVisible={true}
+              setIsVisible={() => setSelectedId(null)}
+            />
           )}
         </>
       )}

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -18,7 +18,7 @@ const HomePage = () => {
     type: null,
   });
 
-  const serverId = globalServer?.id;
+  const serverId = Number(globalServer?.id);
   const { data: homeData, isLoading } = useHomeData(serverId);
 
   if (isLoading) return <div>로딩 중...</div>;
@@ -38,18 +38,21 @@ const HomePage = () => {
     if (selectedItem.type === "groupChatRoom") {
       return groupChatRoom.chatRoomList.find((chat) => chat.id === Number(selectedItem.id));
     }
-    return undefined;
+    return null;
   })();
 
   return (
     <>
-      {selectedChat && (
+      {selectedChat && serverId && (
         <DetailModal
           data={selectedChat}
+          serverId={serverId}
+          selectedItemId={Number(selectedItem.id)}
           isVisible={true}
           setIsVisible={() => setSelectedItem({ type: null, id: null })}
         />
       )}
+
       <div css={s.layoutStyle}>
         <div css={s.leftLayoutStyle}>
           <SearchLayout keyword={keyword} setKeyword={setKeyword} hashTagData={hashTagList} />


### PR DESCRIPTION
## 🎯 관련 이슈

close #96 

<br />

## 🚀 작업 내용
- 채팅방 상세보기 모달에서 입장 아이콘 클릭 시 `enterChatRoom` API 호출 (그룹챗 / 커피챗)
- exitChatRoom API 및 훅 파일 생성  - 추후 채팅방 페이지 완성되면 연결 예정

<br />


## 📸 스크린샷

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c19dc301-cf4e-4543-9f8e-b18f58c64dd1" />

<br />


<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->


## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- 작업에 채팅방 상세보기 모달이 필요해서 #79에서부터 분기해서 진행했습니다. 코리하실 때는 #96만 봐주시면 됩니다!
- 머지 전에 dev로 rebase하겠습니다!


<br />