### PR TITLE
#94 [FEAT] 그룹챗 웹소켓 연결

### DIFF
--- a/src/pages/DMPage/components/ChatRoom/ChatRoom.tsx
+++ b/src/pages/DMPage/components/ChatRoom/ChatRoom.tsx
@@ -7,7 +7,7 @@ import { useScrollToBottom } from "@/hooks/useScroll";
 import { useDmLogs } from "@/pages/DMPage/hooks/useDm";
 import type { ChatRoomProps, DMTypes, StompClientStateTypes } from "@/pages/DMPage/types/dmTypes";
 import { createStompClient } from "@/sockets/dmSocketClient";
-import { parseDateArray } from "@/utils/dateTime";
+import { chatFormatTime } from "@/utils/dateTime";
 import * as s from "@pages/DMPage/components/ChatRoom/ChatRoom.styles";
 import { useEffect, useLayoutEffect, useState } from "react";
 
@@ -22,11 +22,6 @@ const ChatRoom = ({ dmList, roomId, setRoomId }: ChatRoomProps) => {
   const [stompClient, setStompClient] = useState<StompClientStateTypes | null>(null); // STOMP 클라이언트 상태
 
   const userInfo = dmList.find((item) => item.id === roomId)?.user;
-
-  const formatParsedDate = (dateArray: number[]) => {
-    const { hour, minute, meridiem } = parseDateArray(dateArray);
-    return `${meridiem} ${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
-  };
 
   const handleSendMessage = () => {
     if (!stompClient || !stompClient.sendMessage || input.trim() === "") return;
@@ -110,7 +105,7 @@ const ChatRoom = ({ dmList, roomId, setRoomId }: ChatRoomProps) => {
               <ChatPanel
                 isUser={chat.user.id === myId}
                 message={chat.content}
-                time={formatParsedDate(chat.createdDate)}
+                time={chatFormatTime(chat.createdDate)}
                 isDM={true}
               />
             </div>

--- a/src/pages/GroupChatPage/GroupChatPage.tsx
+++ b/src/pages/GroupChatPage/GroupChatPage.tsx
@@ -1,11 +1,13 @@
 import ChatInfoList from "@/pages/GroupChatPage/components/ChatInfoList/ChatInfoList";
 import ChatRoom from "@/pages/GroupChatPage/components/ChatRoom/ChatRoom";
+import { useState } from "react";
 
 const GroupChatPage = () => {
+  const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
+
   return (
     <div css={{ width: "100%", display: "flex" }}>
-      {/* 임의 더미 넣어둠 */}
-      <ChatInfoList name="남다은" />
+      <ChatInfoList name="남다은" setSelectedRoomId={setSelectedRoomId} />
       <ChatRoom />
     </div>
   );

--- a/src/pages/GroupChatPage/GroupChatPage.tsx
+++ b/src/pages/GroupChatPage/GroupChatPage.tsx
@@ -1,14 +1,25 @@
+import ChatEmptyPanel from "@/pages/GroupChatPage/components/ChatEmptyPanel/ChatEmptyPanel";
 import ChatInfoList from "@/pages/GroupChatPage/components/ChatInfoList/ChatInfoList";
 import ChatRoom from "@/pages/GroupChatPage/components/ChatRoom/ChatRoom";
+import { useFetchGroupChat } from "@/pages/GroupChatPage/hooks/useFetchGroupChat";
+import type { ChatRoomTypes } from "@/pages/GroupChatPage/types";
+import type {} from "@/pages/GroupChatPage/types/groupChatLogTypes";
 import { useState } from "react";
+import { useLocation } from "react-router-dom";
 
 const GroupChatPage = () => {
-  const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
+  const [selectedRoom, setSelectedRoom] = useState<ChatRoomTypes | null>(null);
+
+  const { pathname } = useLocation();
+  const serverId = Number(pathname.split("/")[1]);
+
+  const { data: ownerList } = useFetchGroupChat(serverId, "owner");
+  const { data: joinedList } = useFetchGroupChat(serverId, "joined");
 
   return (
     <div css={{ width: "100%", display: "flex" }}>
-      <ChatInfoList name="남다은" setSelectedRoomId={setSelectedRoomId} />
-      <ChatRoom />
+      <ChatInfoList name="남다은" ownerList={ownerList} joinedList={joinedList} setSelectedRoom={setSelectedRoom} />
+      {selectedRoom?.id ? <ChatRoom selectedRoomId={selectedRoom.id} title={selectedRoom.title} /> : <ChatEmptyPanel />}
     </div>
   );
 };

--- a/src/pages/GroupChatPage/apis/fetchGroupChatLogs.ts
+++ b/src/pages/GroupChatPage/apis/fetchGroupChatLogs.ts
@@ -1,0 +1,13 @@
+import { tokenInstance } from "@/apis/instance";
+import type { ChatListResponseTypes } from "@/pages/GroupChatPage/types/groupChatLogTypes";
+
+// [GET] 그룹챗 채팅 로그 조회
+export const fetchGroupChatLogs = async (serverId: number, roomId: number): Promise<ChatListResponseTypes> => {
+  try {
+    const response: ChatListResponseTypes = await tokenInstance(`api/v1/servers/${serverId}/groups/${roomId}`).json();
+    return response;
+  } catch (error) {
+    console.error("그룹챗 채팅 로그 조회 실패:", error);
+    throw error;
+  }
+};

--- a/src/pages/GroupChatPage/apis/fetchSideCoffeeChatList.ts
+++ b/src/pages/GroupChatPage/apis/fetchSideCoffeeChatList.ts
@@ -9,3 +9,4 @@ export const fetchCoffeeChat = async (serverId: number) => {
 
   return response.result;
 };
+

--- a/src/pages/GroupChatPage/apis/fetchSideGroupChatList.ts
+++ b/src/pages/GroupChatPage/apis/fetchSideGroupChatList.ts
@@ -1,11 +1,12 @@
 import { tokenInstance } from "@/apis/instance";
 import type { ChatListTypes } from "@/pages/GroupChatPage/types";
 
-// 사이드 바: 참여한 그룹챗 리스트 조회
-export const fetchGroupChat = async (serverId: number) => {
+// 개설한 그룹챗 조회
+export const fetchGroupChat = async (serverId: number, scope = "owner") => {
   const response = await tokenInstance
-    .get<ChatListTypes>(`api/v1/servers/${serverId}/groups?page=0&sort=name&scope=owner`)
+    .get<ChatListTypes>(`api/v1/servers/${serverId}/groups?page=0&sort=name&scope=${scope}`)
     .json();
 
   return response.result;
 };
+

--- a/src/pages/GroupChatPage/components/ChatEmptyPanel/ChatEmptyPanel.styles.ts
+++ b/src/pages/GroupChatPage/components/ChatEmptyPanel/ChatEmptyPanel.styles.ts
@@ -1,0 +1,37 @@
+import { theme } from "@/styles/theme/theme";
+import bgImg from "@assets/img/dmEmptyBgImg.png";
+import { css } from "@emotion/react";
+
+export const wrapperStyle = css`
+  display: flex;
+
+  width: 100%;
+  height: 100vh;
+
+  padding: 5.3rem 4.5rem 4.2rem 4.5rem;
+
+  z-index: 1;
+
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.9rem;
+
+  background-image: url(${bgImg});
+  background-repeat: no-repeat;
+  background-size: cover;
+
+  border-radius: 2.5rem 0 0 2.5rem;
+
+  background-color: ${theme.color.dark3};
+
+  & > h1 {
+    ${theme.font.title2};
+  }
+
+  & > p {
+    color: ${theme.color.gray2};
+
+    ${theme.font.body1};
+  }
+`;

--- a/src/pages/GroupChatPage/components/ChatEmptyPanel/ChatEmptyPanel.tsx
+++ b/src/pages/GroupChatPage/components/ChatEmptyPanel/ChatEmptyPanel.tsx
@@ -1,0 +1,14 @@
+import { RotateLogoIcon } from "@/assets/svg";
+import * as s from "@pages/DMPage/components/EmptyPanel/EmptyPanel.styles";
+
+const ChatEmptyPanel = () => {
+  return (
+    <div css={s.wrapperStyle}>
+      <RotateLogoIcon width={80} height={70} css={{ marginBottom: "2.7rem", flexShrink: "0" }} />
+      <h1>채팅방 메시지</h1>
+      <p css={{ marginBottom: "1rem" }}>왼쪽 채팅방을 선택해서 대화를 나눠보세요!</p>
+    </div>
+  );
+};
+
+export default ChatEmptyPanel;

--- a/src/pages/GroupChatPage/components/ChatInfoList/ChatInfoList.tsx
+++ b/src/pages/GroupChatPage/components/ChatInfoList/ChatInfoList.tsx
@@ -1,38 +1,35 @@
 import { NoDataContainer } from "@/components";
 import * as s from "@/pages/GroupChatPage/components/ChatInfoList/ChatInfoList.styles";
 import ChatListItem from "@/pages/GroupChatPage/components/ChatListItem/ChatListItem";
-import { useFetchCoffeeChat } from "@/pages/GroupChatPage/hooks/useFetchCoffeeChat";
-import { useFetchGroupChat } from "@/pages/GroupChatPage/hooks/useFetchGroupChat";
+import type { ChatRoomResult, ChatRoomTypes } from "@/pages/GroupChatPage/types";
 
 interface ChatInfoListProps {
+  ownerList: ChatRoomResult;
+  joinedList: ChatRoomResult;
   name: string;
-  setSelectedRoomId: (id: number) => void;
+  setSelectedRoom: (room: ChatRoomTypes) => void;
 }
 
-const ChatInfoList = ({ name, setSelectedRoomId }: ChatInfoListProps) => {
-  const { data: groupChatList } = useFetchGroupChat();
-  const { data: coffeeChatList } = useFetchCoffeeChat();
-
+const ChatInfoList = ({ ownerList, joinedList, name, setSelectedRoom }: ChatInfoListProps) => {
   return (
     <section css={s.sectionStyle}>
       <h1 css={s.nameStyle}>{name}</h1>
 
       <h2 css={s.titleStyle}>내가 개설한 그룹챗</h2>
       <div css={s.listWrapperStyle}>
-        {groupChatList?.chatRoomList?.length > 0 ? (
+        {ownerList?.pageInfo.totalElements > 0 ? (
           <ul css={s.listStyle}>
-            {groupChatList.chatRoomList.map((chat, index) => (
+            {ownerList.chatRoomList.map((chat, index) => (
               <li
                 key={chat.id}
                 onClick={() => {
-                  setSelectedRoomId(chat.id);
-                  console.log(chat.id);
+                  setSelectedRoom(chat);
                 }}
                 onKeyDown={() => {
-                  setSelectedRoomId(chat.id);
+                  setSelectedRoom(chat);
                 }}
               >
-                <ChatListItem name={chat.title} index={index} length={groupChatList.chatRoomList.length} />
+                <ChatListItem name={chat.title} index={index} length={ownerList.pageInfo.totalElements} />
               </li>
             ))}
           </ul>
@@ -43,10 +40,10 @@ const ChatInfoList = ({ name, setSelectedRoomId }: ChatInfoListProps) => {
 
       <h2 css={[s.titleStyle, { marginTop: "2rem" }]}>참여한 그룹챗</h2>
       <div css={s.listWrapperStyle}>
-        {coffeeChatList?.chatRoomList?.length > 0 ? (
+        {joinedList?.pageInfo.totalElements > 0 ? (
           <ul css={s.listStyle}>
-            {coffeeChatList.chatRoomList.map((chat, index) => (
-              <ChatListItem key={chat.id} name={chat.title} index={index} length={coffeeChatList.chatRoomList.length} />
+            {joinedList.chatRoomList.map((chat, index) => (
+              <ChatListItem key={chat.id} name={chat.title} index={index} length={joinedList.pageInfo.totalElements} />
             ))}
           </ul>
         ) : (

--- a/src/pages/GroupChatPage/components/ChatInfoList/ChatInfoList.tsx
+++ b/src/pages/GroupChatPage/components/ChatInfoList/ChatInfoList.tsx
@@ -6,9 +6,10 @@ import { useFetchGroupChat } from "@/pages/GroupChatPage/hooks/useFetchGroupChat
 
 interface ChatInfoListProps {
   name: string;
+  setSelectedRoomId: (id: number) => void;
 }
 
-const ChatInfoList = ({ name }: ChatInfoListProps) => {
+const ChatInfoList = ({ name, setSelectedRoomId }: ChatInfoListProps) => {
   const { data: groupChatList } = useFetchGroupChat();
   const { data: coffeeChatList } = useFetchCoffeeChat();
 
@@ -21,7 +22,18 @@ const ChatInfoList = ({ name }: ChatInfoListProps) => {
         {groupChatList?.chatRoomList?.length > 0 ? (
           <ul css={s.listStyle}>
             {groupChatList.chatRoomList.map((chat, index) => (
-              <ChatListItem key={chat.id} name={chat.title} index={index} length={groupChatList.chatRoomList.length} />
+              <li
+                key={chat.id}
+                onClick={() => {
+                  setSelectedRoomId(chat.id);
+                  console.log(chat.id);
+                }}
+                onKeyDown={() => {
+                  setSelectedRoomId(chat.id);
+                }}
+              >
+                <ChatListItem name={chat.title} index={index} length={groupChatList.chatRoomList.length} />
+              </li>
             ))}
           </ul>
         ) : (

--- a/src/pages/GroupChatPage/components/ChatListItem/ChatListItem.styles.ts
+++ b/src/pages/GroupChatPage/components/ChatListItem/ChatListItem.styles.ts
@@ -25,10 +25,10 @@ export const listWrapperStyle = (isMarked: boolean) => css`
   }
 
   svg {
-    :nth-child(2) {
+    :nth-of-type(2) {
       path {
         fill: ${isMarked ? theme.color.primaryBlue2 : "transparent"};
-        stroke: ${isMarked ? theme.color.primaryBlue2 : theme.color.dark1}
+        stroke: ${isMarked ? theme.color.primaryBlue2 : theme.color.dark1};
       }
     }
   }

--- a/src/pages/GroupChatPage/components/ChatListItem/ChatListItem.tsx
+++ b/src/pages/GroupChatPage/components/ChatListItem/ChatListItem.tsx
@@ -18,7 +18,7 @@ const ChatListItem = ({ name, index, length }: ChatListItemProps) => {
   };
 
   return (
-    <li>
+    <>
       <div css={s.listWrapperStyle(isMarked)}>
         <span css={s.layoutStyle}>
           <RotateLogoIcon width={14} height={12} css={{ flexShrink: "0" }} />
@@ -27,7 +27,7 @@ const ChatListItem = ({ name, index, length }: ChatListItemProps) => {
         <StarIcon width={18} height={18} onClick={toggle} css={{ flexShrink: "0", cursor: "pointer" }} />
       </div>
       {length > 1 && index < length - 1 && <Divider css={{ backgroundColor: theme.color.dark5 }} />}
-    </li>
+    </>
   );
 };
 

--- a/src/pages/GroupChatPage/components/ChatRoom/ChatRoom.tsx
+++ b/src/pages/GroupChatPage/components/ChatRoom/ChatRoom.tsx
@@ -5,39 +5,91 @@ import TimeChip from "@/components/TimeChip/TimeChip";
 
 import { PLACEHOLDER } from "@/constants/placeholder";
 import { useScrollToBottom } from "@/hooks/useScroll";
-import { DUMMY_CHAT_MESSAGES } from "@/pages/GroupChatPage/constants/dummy";
+import { useChatScroll } from "@/pages/GroupChatPage/hooks/useChatScroll";
+import { useFetchGroupChatLogs } from "@/pages/GroupChatPage/hooks/useFetchGroupChatLogs";
+import { useGroupChatStompClient } from "@/pages/GroupChatPage/hooks/useGroupChatStompClient";
+import { useUpdateChatLogs } from "@/pages/GroupChatPage/hooks/useUpdateChatLogs";
+import type { ChatTypes } from "@/pages/GroupChatPage/types/groupChatLogTypes";
+import { chatFormatTime } from "@/utils/dateTime";
 import * as s from "@pages/GroupChatPage/components/ChatRoom/ChatRoom.styles";
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 
-const ChatRoom = () => {
+interface ChatRoomProps {
+  selectedRoomId: number;
+  title: string;
+}
+
+const ChatRoom = ({ selectedRoomId, title }: ChatRoomProps) => {
+  const [logs, setLogs] = useState<ChatTypes[]>([]);
+  const [input, setInput] = useState("");
+
+  const { pathname } = useLocation();
+  const serverId = Number(pathname.split("/")[1]);
+
+  const stompClient = useGroupChatStompClient(selectedRoomId, setLogs);
   const scrollRef = useScrollToBottom();
 
+  useUpdateChatLogs(serverId, selectedRoomId, setLogs);
+  useChatScroll(scrollRef, logs);
+
+  const { data } = useFetchGroupChatLogs(serverId, selectedRoomId);
+
+  const myId = Number(localStorage.getItem("userId")) || null;
+
+  const handleSendMessage = () => {
+    if (!stompClient || !stompClient.sendMessage || input.trim() === "") return;
+    stompClient.sendMessage(input);
+    setInput("");
+  };
+
+  const reversedChatLogs = [...logs].reverse();
+
+  useEffect(() => {
+    if (data?.result.chatList) {
+      setLogs(data.result.chatList);
+    }
+  }, [data]);
   return (
     <section css={s.wrapperStyle}>
       <header css={s.headerLayoutStyle}>
         <div css={s.titleLayoutStyle}>
           <RotateLogoIcon width={25} height={22} />
-          {/* 임시 더미 */}
-          <h1 css={s.titleStyle}>강남 오프라인</h1>
-          <TimeChip size="large" time="11/2 (월) 18:30" />
+          <h1 css={s.titleStyle}>{title}</h1>
         </div>
         <HamburgerIcon width={23} height={15} css={s.iconStyle} onClick={() => {}} />
       </header>
       <div css={s.scrollStyle} ref={scrollRef}>
-        {DUMMY_CHAT_MESSAGES.map((chat, index) => (
-          <div key={`${index}-${chat.time}`} css={s.layoutStyle(chat.isUser)}>
-            {!chat.isUser && <UserBox name={chat.userName} />}
-
-            <div css={{ display: "flex", flexDirection: "column", gap: "0.8rem" }}>
-              <div css={s.nameBoxStyle(chat.isUser)}>
-                {chat.userName}
-                <TimeChip time={chat.time} />
+        {reversedChatLogs.map((chat, index) => {
+          const isUser = chat.user.id === myId;
+          return (
+            <div key={`${index}-${chat.id}`} css={s.layoutStyle(isUser)}>
+              {!isUser && <UserBox name={chat.user.nickname} />}
+              <div css={{ display: "flex", flexDirection: "column", gap: "0.8rem" }}>
+                <div css={s.nameBoxStyle(isUser)}>
+                  {chat.user.nickname}
+                  <TimeChip time={chatFormatTime(chat.createdDate)} />
+                </div>
+                <ChatPanel
+                  isUser={isUser}
+                  message={chat.content}
+                  time={chatFormatTime(chat.createdDate)}
+                  isDM={false}
+                />
               </div>
-              <ChatPanel isUser={chat.isUser} message={chat.message} time={chat.time} isDM={false} />
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
-      <Input placeholder={PLACEHOLDER.CHAT} rightIcon={<SendIcon width={14} height={14} />} />
+      <Input
+        placeholder={PLACEHOLDER.CHAT}
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyUp={(e) => {
+          if (e.key === "Enter") handleSendMessage();
+        }}
+        rightIcon={<SendIcon width={14} height={14} />}
+      />
     </section>
   );
 };

--- a/src/pages/GroupChatPage/hooks/useChatScroll.ts
+++ b/src/pages/GroupChatPage/hooks/useChatScroll.ts
@@ -1,0 +1,11 @@
+import type { ChatTypes } from "@/pages/HomePage/types/homeDataTypes";
+import { type RefObject, useLayoutEffect } from "react";
+
+export const useChatScroll = (scrollRef: RefObject<HTMLElement | null>, dependency: ChatTypes[]) => {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Ignore unnecessary dependency warning
+  useLayoutEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [dependency]);
+};

--- a/src/pages/GroupChatPage/hooks/useFetchGroupChat.ts
+++ b/src/pages/GroupChatPage/hooks/useFetchGroupChat.ts
@@ -1,12 +1,9 @@
 import { fetchGroupChat } from "@/pages/GroupChatPage/apis/fetchSideGroupChatList";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useParams } from "react-router-dom";
 
-export const useFetchGroupChat = () => {
-  const { serverId } = useParams();
-
+export const useFetchGroupChat = (serverId: number, scope: string) => {
   return useSuspenseQuery({
-    queryKey: ["fetchGroupChatList"],
-    queryFn: () => fetchGroupChat(Number(serverId)),
+    queryKey: ["fetchGroupChatList", serverId, scope],
+    queryFn: () => fetchGroupChat(serverId, scope),
   });
 };

--- a/src/pages/GroupChatPage/hooks/useFetchGroupChatLogs.ts
+++ b/src/pages/GroupChatPage/hooks/useFetchGroupChatLogs.ts
@@ -1,0 +1,11 @@
+import { fetchGroupChatLogs } from "@/pages/GroupChatPage/apis/fetchGroupChatLogs";
+import { useQuery } from "@tanstack/react-query";
+
+// 채팅 로그 조회 API 훅
+export const useFetchGroupChatLogs = (serverId: number | null, roomId: number) => {
+  return useQuery({
+    queryKey: ["groupChatLogs", serverId, roomId],
+    queryFn: () => (serverId !== null ? fetchGroupChatLogs(serverId, roomId) : Promise.reject("serverId is null")),
+    enabled: !!serverId,
+  });
+};

--- a/src/pages/GroupChatPage/hooks/useGroupChatStompClient.ts
+++ b/src/pages/GroupChatPage/hooks/useGroupChatStompClient.ts
@@ -1,0 +1,37 @@
+import type { StompClientStateTypes } from "@/pages/DMPage/types/dmTypes";
+import type { ChatTypes } from "@/pages/GroupChatPage/types/groupChatLogTypes";
+import { createStompClient } from "@/sockets/chatSocketClient";
+import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
+
+// STOMP 클라이언트 설정 훅
+export const useGroupChatStompClient = (roomId: number, setGroupChatLogs: Dispatch<SetStateAction<ChatTypes[]>>) => {
+  const [stompClient, setStompClient] = useState<StompClientStateTypes | null>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Ignore unnecessary dependency warning
+  useEffect(() => {
+    if (roomId) {
+      const stomp = createStompClient(roomId, (messageContent: string) => {
+        const messageData = JSON.parse(messageContent);
+
+        setGroupChatLogs((prevLogs) => {
+          if (!prevLogs.find((msg) => msg.id === messageData.id)) {
+            return [messageData, ...prevLogs];
+          }
+          return prevLogs;
+        });
+      });
+
+      if (stomp.client && typeof stomp.sendMessage === "function") {
+        setStompClient(stomp);
+      }
+    }
+
+    return () => {
+      if (stompClient?.client) {
+        stompClient.client.deactivate();
+      }
+    };
+  }, [roomId]);
+
+  return stompClient;
+};

--- a/src/pages/GroupChatPage/hooks/useUpdateChatLogs.ts
+++ b/src/pages/GroupChatPage/hooks/useUpdateChatLogs.ts
@@ -1,0 +1,15 @@
+import { useFetchGroupChatLogs } from "@/pages/GroupChatPage/hooks/useFetchGroupChatLogs";
+import type { ChatTypes } from "@/pages/GroupChatPage/types/groupChatLogTypes";
+
+import { type Dispatch, type SetStateAction, useEffect } from "react";
+
+// 채팅 로그 상태 관리 훅
+export const useUpdateChatLogs = (serverId: number, roomId: number, setGlobalChatLogs: Dispatch<SetStateAction<ChatTypes[]>>) => {
+  const { data } = useFetchGroupChatLogs(serverId, roomId);
+
+  useEffect(() => {
+    if (data?.result.chatList) {
+      setGlobalChatLogs(data.result.chatList);
+    }
+  }, [data, setGlobalChatLogs]);
+};

--- a/src/pages/GroupChatPage/types/groupChatLogTypes.ts
+++ b/src/pages/GroupChatPage/types/groupChatLogTypes.ts
@@ -1,0 +1,39 @@
+interface UserIntro {
+  headline: string;
+  job: string;
+  expYears: number;
+}
+
+interface User {
+  id: number;
+  profileImage: string;
+  nickname: string;
+  linkedInVerify: boolean;
+  userIntro: UserIntro;
+}
+
+export interface ChatTypes {
+  id: number;
+  user: User;
+  content: string;
+  createdDate: number[];
+  type: string;
+  chatRoomId: number;
+}
+
+export interface PageInfoTypes {
+  lastPage: boolean;
+  totalPages: number;
+  totalElements: number;
+  size: number;
+}
+
+export interface ChatListResponseTypes {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    pageInfo: PageInfoTypes;
+    chatList: ChatTypes[];
+  };
+}

--- a/src/pages/GroupChatPage/types/index.ts
+++ b/src/pages/GroupChatPage/types/index.ts
@@ -3,7 +3,7 @@ interface Period {
   endDate: string | null;
 }
 
-interface ChatRoom {
+export interface ChatRoomTypes {
   id: number;
   thumbnail: string | null;
   title: string;
@@ -18,9 +18,9 @@ interface PageInfo {
   size: number;
 }
 
-interface ChatRoomResult {
+export interface ChatRoomResult {
   pageInfo: PageInfo;
-  chatRoomList: ChatRoom[];
+  chatRoomList: ChatRoomTypes[];
 }
 
 export interface ChatListTypes {

--- a/src/utils/dateTime.ts
+++ b/src/utils/dateTime.ts
@@ -58,7 +58,7 @@ export const parseDateArray = (dateArray: number[]) => {
 };
 
 export const requestFormatTime = (
-  dateTime: FormDateTimeTypes,
+  dateTime: FormDateTimeTypes
 ): {
   startDate: RequestDateType;
   endDate: RequestDateType;
@@ -115,4 +115,9 @@ export const timeAgo = (dateArray: number[]) => {
     return `${diffInHours}시간`;
   }
   return `${diffInDays}일`;
+};
+
+export const chatFormatTime = (dateArray: number[]) => {
+  const { hour, minute, meridiem } = parseDateArray(dateArray);
+  return `${meridiem} ${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
 };


### PR DESCRIPTION
## 🎯 관련 이슈

close #94 

<br />

## 🚀 작업 내용
- 그룹챗 목록 조회 사이드 바
  - 내가 개설한/참여한 그룹챗 리스트 API 연결
 
- 그룹챗 채팅
  - 채팅 이력 조회
  - 실시간 채팅 연결
  - 채팅할 그룹챗을 선택하지 않았을 경우(그룹챗 페이지 처음 들어왔을 때) ChatEmptyPannel 띄우기

<br />


## 📸 스크린샷

![image](https://github.com/user-attachments/assets/0434c626-95a4-4f36-a019-986286d157b9)

![image](https://github.com/user-attachments/assets/ff37b362-5afa-4267-b95b-a394c5a6e2eb)

<br />


<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->


## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?
- 지금 머지가 안 된 것들 중 겹치는 부분이 많아서 겹치는 코드들도 새롭게 파일 추가하는 형식으로 작업했습니다.
- 겹치는 부분들은 나중에 시간 될 때 천천히 리팩해야 될 것 같아요 😅
- 사이드바 채팅방 목록에서 `내가 참여한 그룹챗`부분에 커피챗을 가져와 띄우는 오류가 있어 수정했습니다!
- 아래 사진을 보면, 목록에 요소가 없을 경우 띄워주는 NoDataContainer는 UI가 깨져서 다른 ui로 교체해야 할 듯 합니다.
<img width="194" alt="스크린샷 2025-03-18 오전 3 36 31" src="https://github.com/user-attachments/assets/71d41577-eb36-41a7-b38f-e3b737e9af6a" />

<br />

