### PR TITLE
#103 [FEAT] 검색 API 연결

### DIFF
--- a/src/components/SearchLayout/SearchLayout.tsx
+++ b/src/components/SearchLayout/SearchLayout.tsx
@@ -24,7 +24,7 @@ const SearchLayout = ({ queryParam, setQueryParam, hashTagData }: SearchLayoutPr
       />
       <ul css={s.hashTagListStyle}>
         {hashTagData.map((tag) => {
-          const isSelected = queryParam.tagList.includes(tag.content);
+          const isSelected = queryParam.tags.includes(tag.content);
           return (
             <li key={tag.id}>
               <Button

--- a/src/components/SearchLayout/SearchLayout.tsx
+++ b/src/components/SearchLayout/SearchLayout.tsx
@@ -1,31 +1,51 @@
 import { RotateLogoIcon } from "@/assets/svg";
 import { Button, Input } from "@/components";
-import type { HashtagTypes } from "@/pages/HomePage/types/homeDataTypes";
+import { useUpdateSearchParam } from "@/components/SearchLayout/hooks/useUpdateSearchParam";
+import type { QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
+import type { HashtagTypes } from "@/components/TagChip/types/tagChipTypes";
+import { useEffect } from "react";
 import * as s from "./SearchLayout.styles";
 
 interface SearchLayoutProps {
-  keyword: string;
-  setKeyword: (value: string) => void;
+  queryParam: QueryParamTypes;
+  setQueryParam: (searchParam: QueryParamTypes) => void;
   hashTagData: HashtagTypes[];
 }
 
-const SearchLayout = ({ keyword, setKeyword, hashTagData }: SearchLayoutProps) => {
+const SearchLayout = ({ queryParam, setQueryParam, hashTagData }: SearchLayoutProps) => {
+  const { updateField, updateTagList } = useUpdateSearchParam(queryParam, setQueryParam);
+
+  useEffect(() => {
+    console.log("queryParam: ", queryParam);
+  }, [queryParam]);
   return (
     <div css={s.searchLayoutStyle}>
       <Input
         leftIcon={<RotateLogoIcon width={18} />}
         placeholder="관심있는 키워드를 검색해보세요!"
-        value={keyword}
-        onChange={(e) => setKeyword(e.target.value)}
+        value={queryParam.keyword}
+        onChange={(e) => updateField("keyword", e.target.value)}
       />
       <ul css={s.hashTagListStyle}>
-        {hashTagData.map((tag) => (
-          <li key={tag.id}>
-            <Button variant="hashtag" size="semiLarge" onClick={() => setKeyword(tag.content)}>
-              {tag.content}
-            </Button>
-          </li>
-        ))}
+        {hashTagData.map((tag) => {
+          const isSelected = queryParam.tagList.includes(tag.content);
+          return (
+            <li key={tag.id}>
+              <Button
+                variant="hashtag"
+                size="semiLarge"
+                onClick={() => updateTagList(tag.content)}
+                css={{
+                  color: isSelected ? "white" : "",
+                  backgroundColor: isSelected ? "#3f4b5d;" : "",
+                  fontWeight: isSelected ? "500;" : "",
+                }}
+              >
+                {tag.content}
+              </Button>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/src/components/SearchLayout/SearchLayout.tsx
+++ b/src/components/SearchLayout/SearchLayout.tsx
@@ -3,7 +3,6 @@ import { Button, Input } from "@/components";
 import { useUpdateSearchParam } from "@/components/SearchLayout/hooks/useUpdateSearchParam";
 import type { QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
 import type { HashtagTypes } from "@/components/TagChip/types/tagChipTypes";
-import { useEffect } from "react";
 import * as s from "./SearchLayout.styles";
 
 interface SearchLayoutProps {
@@ -15,9 +14,6 @@ interface SearchLayoutProps {
 const SearchLayout = ({ queryParam, setQueryParam, hashTagData }: SearchLayoutProps) => {
   const { updateField, updateTagList } = useUpdateSearchParam(queryParam, setQueryParam);
 
-  useEffect(() => {
-    console.log("queryParam: ", queryParam);
-  }, [queryParam]);
   return (
     <div css={s.searchLayoutStyle}>
       <Input

--- a/src/components/SearchLayout/apis/search.ts
+++ b/src/components/SearchLayout/apis/search.ts
@@ -13,7 +13,7 @@ export const fetchSearchResult = async ({
     const queryParams = new URLSearchParams();
 
     queryParams.append("page", page.toString());
-    if (sort) queryParams.append("sort", sort); //
+    if (sort && sort !== "default") queryParams.append("sort", sort);
     if (scope) queryParams.append("scope", scope);
     if (keyword) queryParams.append("keyword", keyword);
     if (tagList && tagList.length > 0) {
@@ -22,10 +22,8 @@ export const fetchSearchResult = async ({
       }
     }
 
-    console.log(queryParams.toString());
-
     const response: GroupChatListResponse = await tokenInstance
-      .get(`api/v1/servers/${serverId}/${type}?${queryParams.toString()}`)
+      .get(`api/v1/servers/${serverId}/${type}?${queryParams}`)
       .json();
 
     return response;

--- a/src/components/SearchLayout/apis/search.ts
+++ b/src/components/SearchLayout/apis/search.ts
@@ -8,7 +8,7 @@ export const fetchSearchResult = async ({
   queryParam,
 }: SearchParamTypes): Promise<GroupChatListResponse> => {
   try {
-    const { page, sort, scope, keyword, tagList } = queryParam;
+    const { page, sort, scope, keyword, tags } = queryParam;
 
     const queryParams = new URLSearchParams();
 
@@ -16,9 +16,9 @@ export const fetchSearchResult = async ({
     if (sort && sort !== "default") queryParams.append("sort", sort);
     if (scope) queryParams.append("scope", scope);
     if (keyword) queryParams.append("keyword", keyword);
-    if (tagList && tagList.length > 0) {
-      for (const tag of tagList) {
-        queryParams.append("tagList", tag);
+    if (tags && tags.length > 0) {
+      for (const tag of tags) {
+        queryParams.append("tags", tag);
       }
     }
 

--- a/src/components/SearchLayout/apis/search.ts
+++ b/src/components/SearchLayout/apis/search.ts
@@ -1,0 +1,36 @@
+import { tokenInstance } from "@/apis/instance";
+import type { SearchParamTypes } from "@/components/SearchLayout/types/searchTypes";
+import type { GroupChatListResponse } from "@/pages/GroupChatListPage/types/groupChatTypes";
+
+export const fetchSearchResult = async ({
+  serverId,
+  type,
+  queryParam,
+}: SearchParamTypes): Promise<GroupChatListResponse> => {
+  try {
+    const { page, sort, scope, keyword, tagList } = queryParam;
+
+    const queryParams = new URLSearchParams();
+
+    queryParams.append("page", page.toString());
+    if (sort) queryParams.append("sort", sort); //
+    if (scope) queryParams.append("scope", scope);
+    if (keyword) queryParams.append("keyword", keyword);
+    if (tagList && tagList.length > 0) {
+      for (const tag of tagList) {
+        queryParams.append("tagList", tag);
+      }
+    }
+
+    console.log(queryParams.toString());
+
+    const response: GroupChatListResponse = await tokenInstance
+      .get(`api/v1/servers/${serverId}/${type}?${queryParams.toString()}`)
+      .json();
+
+    return response;
+  } catch (error) {
+    console.error("검색 실패:", error);
+    throw error;
+  }
+};

--- a/src/components/SearchLayout/hooks/useDebounce.ts
+++ b/src/components/SearchLayout/hooks/useDebounce.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+const useDebounce = <T>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/components/SearchLayout/hooks/useSearch.ts
+++ b/src/components/SearchLayout/hooks/useSearch.ts
@@ -1,0 +1,19 @@
+import { fetchSearchResult } from "@/components/SearchLayout/apis/search";
+import useDebounce from "@/components/SearchLayout/hooks/useDebounce";
+import type { SearchParamTypes } from "@/components/SearchLayout/types/searchTypes";
+import { useQuery } from "@tanstack/react-query";
+
+export const useSearch = ({ serverId, type, queryParam }: SearchParamTypes) => {
+  const debouncedQueryParam = useDebounce(queryParam, 500);
+
+  return useQuery({
+    queryKey: ["searchResult", serverId, type, debouncedQueryParam],
+    queryFn: () =>
+      fetchSearchResult({
+        serverId,
+        type,
+        queryParam: debouncedQueryParam,
+      }),
+    enabled: !!serverId && !!type && !!debouncedQueryParam,
+  });
+};

--- a/src/components/SearchLayout/hooks/useUpdateSearchParam.ts
+++ b/src/components/SearchLayout/hooks/useUpdateSearchParam.ts
@@ -9,13 +9,13 @@ export const useUpdateSearchParam = (param: QueryParamTypes, setParam: (param: Q
   };
 
   const updateTagList = (tagContent: string) => {
-    const isTagExist = param.tagList.includes(tagContent);
+    const isTagExist = param.tags.includes(tagContent);
 
     const updatedTagList = isTagExist
-      ? param.tagList.filter((tagContentInList) => tagContentInList !== tagContent)
-      : [...param.tagList, tagContent];
+      ? param.tags.filter((tagContentInList) => tagContentInList !== tagContent)
+      : [...param.tags, tagContent];
 
-    updateField("tagList", updatedTagList);
+    updateField("tags", updatedTagList);
   };
 
   return { updateField, updateTagList };

--- a/src/components/SearchLayout/hooks/useUpdateSearchParam.ts
+++ b/src/components/SearchLayout/hooks/useUpdateSearchParam.ts
@@ -1,0 +1,22 @@
+import type { QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
+
+export const useUpdateSearchParam = (param: QueryParamTypes, setParam: (param: QueryParamTypes) => void) => {
+  const updateField = (field: keyof QueryParamTypes, value: string | number | string[]) => {
+    setParam({
+      ...param,
+      [field]: value,
+    });
+  };
+
+  const updateTagList = (tagContent: string) => {
+    const isTagExist = param.tagList.includes(tagContent);
+
+    const updatedTagList = isTagExist
+      ? param.tagList.filter((tagContentInList) => tagContentInList !== tagContent)
+      : [...param.tagList, tagContent];
+
+    updateField("tagList", updatedTagList);
+  };
+
+  return { updateField, updateTagList };
+};

--- a/src/components/SearchLayout/types/searchTypes.ts
+++ b/src/components/SearchLayout/types/searchTypes.ts
@@ -1,0 +1,15 @@
+export interface QueryParamTypes {
+  page: number;
+  sort: "name" | "remain" | "";
+  scope: "joined" | "owner" | "";
+  keyword: string;
+  tagList: string[];
+}
+
+export interface SearchParamTypes {
+  serverId: number;
+  type: string;
+  queryParam: QueryParamTypes;
+}
+
+

--- a/src/components/SearchLayout/types/searchTypes.ts
+++ b/src/components/SearchLayout/types/searchTypes.ts
@@ -3,7 +3,7 @@ export interface QueryParamTypes {
   sort: string;
   scope: "joined" | "owner" | "";
   keyword: string;
-  tagList: string[];
+  tags: string[];
 }
 
 export interface SearchParamTypes {

--- a/src/components/SearchLayout/types/searchTypes.ts
+++ b/src/components/SearchLayout/types/searchTypes.ts
@@ -1,6 +1,6 @@
 export interface QueryParamTypes {
   page: number;
-  sort: "name" | "remain" | "";
+  sort: string;
   scope: "joined" | "owner" | "";
   keyword: string;
   tagList: string[];

--- a/src/components/TagChip/types/tagChipTypes.ts
+++ b/src/components/TagChip/types/tagChipTypes.ts
@@ -4,3 +4,8 @@ export interface TagChipTypes {
   id: number;
   content: ReactNode;
 }
+
+export interface HashtagTypes {
+  id: number;
+  content: string;
+}

--- a/src/components/TitleContainer/TitleContainer.tsx
+++ b/src/components/TitleContainer/TitleContainer.tsx
@@ -1,6 +1,6 @@
 import { ArrowDownIcon } from "@/assets/svg";
 import { Button } from "@/components";
-import { type DropdownOptionTypes, SORTING_OPTIONS } from "@/constants/dropdown";
+import type { DropdownOptionTypes } from "@/constants/dropdown";
 import type { HTMLAttributes, ReactNode } from "react";
 import { useState } from "react";
 import Dropdown from "../Dropdown/Dropdown";
@@ -52,7 +52,7 @@ const TitleContainer = ({
             </Button>
             {dropdownOpen && (
               <Dropdown
-                options={SORTING_OPTIONS}
+                options={sortingOptions}
                 setItem={setSortingOption}
                 dropDownOpen={dropdownOpen}
                 setDropdownOpen={setDropdownOpen}

--- a/src/constants/dropdown.ts
+++ b/src/constants/dropdown.ts
@@ -9,9 +9,15 @@ export const SCHEDULE_FILTERING_OPTIONS = [
   { id: "LAST_12_MONTHS", name: "1년 이상" },
 ];
 
-export const SORTING_OPTIONS = [
-  { id: "BY_LATEST", name: "최신순" },
-  { id: "BY_DEADLINE", name: "마감 임박순" },
+export const GROUP_SORTING_OPTIONS = [
+  { id: "default", name: "최신순" },
+  { id: "name", name: "이름순" },
+];
+
+export const MEETING_SORTING_OPTIONS = [
+  { id: "default", name: "최신순" },
+  { id: "name", name: "이름순" },
+  { id: "remain", name: "마감 임박순" },
 ];
 
 export const AMPM_OPTIONS = [

--- a/src/pages/CoffeeChatListPage/CoffeeChatListPage.tsx
+++ b/src/pages/CoffeeChatListPage/CoffeeChatListPage.tsx
@@ -1,33 +1,47 @@
 import { AddButton, SearchLayout, TitleContainer } from "@/components";
-import { SORTING_OPTIONS } from "@/constants/dropdown";
-import { HASH_TAGS_DUMMY } from "@/constants/hashTagsDummy";
+import { useSearch } from "@/components/SearchLayout/hooks/useSearch";
+import type { QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
+import { MEETING_SORTING_OPTIONS } from "@/constants/dropdown";
 import { useState } from "react";
+import { useLocation, useParams } from "react-router-dom";
 import * as s from "./CoffeeChatListPage.styles";
 import AddCoffeeChatModal from "./components/AddCoffeeChatModal/AddCoffeeChatModal";
 import CoffeeChatListAll from "./components/CoffeeChatListAll/CoffeeChatListAll";
 
 const CoffeeChatListPage = () => {
-  const [sortingOption, setSortingOption] = useState(SORTING_OPTIONS[0]);
-  const [keyword, setKeyword] = useState("");
   const [isModalVisible, setIsModalVisible] = useState(false);
+
+  const { serverId: param } = useParams();
+  const serverId = Number(param);
+
+  const location = useLocation();
+  const hashTagData = location.state?.hashTagData || [];
+
+  const [queryParam, setQueryParam] = useState<QueryParamTypes>({
+    page: 0,
+    sort: MEETING_SORTING_OPTIONS[0].id,
+    scope: "",
+    keyword: "",
+    tagList: [],
+  });
+
+  const { data } = useSearch({
+    serverId,
+    type: "groups",
+    queryParam,
+  });
+  console.log(data);
 
   return (
     <div css={s.layoutStyle}>
-      <AddCoffeeChatModal
-        isVisible={isModalVisible}
-        setIsVisible={setIsModalVisible}
-      />
+      <AddCoffeeChatModal isVisible={isModalVisible} setIsVisible={setIsModalVisible} />
       <AddButton setIsModalVisible={setIsModalVisible} />
-      <SearchLayout
-        keyword={keyword}
-        setKeyword={setKeyword}
-        hashTagData={HASH_TAGS_DUMMY}
-      />
+      <SearchLayout queryParam={queryParam} setQueryParam={setQueryParam} hashTagData={hashTagData} />
       <TitleContainer
         title="오프라인 커피챗"
-        sortingOptions={SORTING_OPTIONS}
-        sortingOption={sortingOption}
-        setSortingOption={setSortingOption}
+        sortingOptions={MEETING_SORTING_OPTIONS}
+        sortingOption={MEETING_SORTING_OPTIONS.find((option) => option.id === queryParam.sort)}
+        setSortingOption={(newOpt) => setQueryParam((prev) => ({ ...prev, sort: newOpt.id }))}
       >
         <CoffeeChatListAll />
       </TitleContainer>

--- a/src/pages/CoffeeChatListPage/CoffeeChatListPage.tsx
+++ b/src/pages/CoffeeChatListPage/CoffeeChatListPage.tsx
@@ -22,7 +22,7 @@ const CoffeeChatListPage = () => {
     sort: MEETING_SORTING_OPTIONS[0].id,
     scope: "",
     keyword: "",
-    tagList: [],
+    tags: [],
   });
 
   const { data } = useSearch({

--- a/src/pages/CoffeeChatListPage/CoffeeChatListPage.tsx
+++ b/src/pages/CoffeeChatListPage/CoffeeChatListPage.tsx
@@ -27,10 +27,9 @@ const CoffeeChatListPage = () => {
 
   const { data } = useSearch({
     serverId,
-    type: "groups",
+    type: "meetings",
     queryParam,
   });
-  console.log(data);
 
   return (
     <div css={s.layoutStyle}>
@@ -43,7 +42,7 @@ const CoffeeChatListPage = () => {
         sortingOption={MEETING_SORTING_OPTIONS.find((option) => option.id === queryParam.sort)}
         setSortingOption={(newOpt) => setQueryParam((prev) => ({ ...prev, sort: newOpt.id }))}
       >
-        <CoffeeChatListAll />
+        {data && <CoffeeChatListAll serverId={serverId} data={data} />}
       </TitleContainer>
     </div>
   );

--- a/src/pages/CoffeeChatListPage/components/CoffeeChatListAll/CoffeeChatListAll.tsx
+++ b/src/pages/CoffeeChatListPage/components/CoffeeChatListAll/CoffeeChatListAll.tsx
@@ -1,27 +1,21 @@
 import rotateLogoImg from "@/assets/img/rotateLogoImg.png";
 import { RotateLogoIcon } from "@/assets/svg";
 import { DetailModal, NoDataContainer } from "@/components";
-import { useFetchCoffeeChatList } from "@/pages/CoffeeChatListPage/hooks/useFetchCoffeeChatList";
 import type { CoffeeChatListResponse } from "@/pages/CoffeeChatListPage/types/coffeeChatTypes";
 import { parseDateArray } from "@/utils/dateTime";
 import { useState } from "react";
-import { useLocation } from "react-router-dom";
 import * as s from "./CoffeeChatListAll.styles";
 
-const CoffeeChatListAll = () => {
-  const { pathname } = useLocation();
-  const serverId = Number(pathname.split("/")[1]);
+interface CoffeeChatListAllProps {
+  serverId: number;
+  data: CoffeeChatListResponse;
+}
 
-  const { data } = useFetchCoffeeChatList(serverId) as { data?: CoffeeChatListResponse };
-
+const CoffeeChatListAll = ({ serverId, data }: CoffeeChatListAllProps) => {
   const items = data?.result.chatRoomList;
   const itemsCount = items?.length;
 
   const [selectedId, setSelectedId] = useState<number | null>(null);
-
-  const handleItemClick = (id: number) => {
-    setSelectedId(id);
-  };
 
   const handleCloseModal = () => {
     setSelectedId(null);
@@ -30,7 +24,7 @@ const CoffeeChatListAll = () => {
   const selectedChat = items?.find((chat) => chat.id === selectedId);
 
   const dateTimeFormat = (dateArray: number[] | null) => {
-    if (!dateArray) return ;
+    if (!dateArray) return;
     const parsed = parseDateArray(dateArray);
     return `${parsed.month}/${parsed.day} ${parsed.meridiem} ${String(parsed.hour).padStart(2, "0")}:${String(
       parsed.minute
@@ -47,8 +41,8 @@ const CoffeeChatListAll = () => {
             <li key={chat.id} style={{ paddingRight: "0" }}>
               <article
                 css={s.listItemStyle}
-                onClick={() => handleItemClick(chat.id)}
-                onKeyDown={() => handleItemClick(chat.id)}
+                onClick={() => setSelectedId(chat.id)}
+                onKeyDown={() => setSelectedId(chat.id)}
               >
                 <img
                   src={chat.thumbnail || rotateLogoImg}
@@ -80,7 +74,13 @@ const CoffeeChatListAll = () => {
       )}
 
       {selectedChat && (
-        <DetailModal data={selectedChat} isCoffeeChat={true} isVisible={true} setIsVisible={handleCloseModal} />
+        <DetailModal
+          data={selectedChat}
+          serverId={serverId}
+          selectedItemId={selectedChat.id}
+          isCoffeeChat={true}
+          setIsVisible={handleCloseModal}
+        />
       )}
     </div>
   );

--- a/src/pages/GlobalChatPage/components/GlobalChatRoom/GlobalChatRoom.tsx
+++ b/src/pages/GlobalChatPage/components/GlobalChatRoom/GlobalChatRoom.tsx
@@ -9,6 +9,7 @@ import { useGlobalChatStompClient } from "@/pages/GlobalChatPage/hooks/useGlobal
 import { useUpdateChatLogs } from "@/pages/GlobalChatPage/hooks/useUpdateChatLogs";
 import type { ChatTypes } from "@/pages/GlobalChatPage/types/globalChatTypes";
 import { globalChatFormatTime } from "@/pages/GlobalChatPage/utils/globalChatFormatTime";
+import { CHAT_NOTICE_DEFAULT } from "@/pages/HomePage/constants/noticeDummy";
 import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import * as s from "./GlobalChatRoom.styles";
@@ -57,13 +58,7 @@ const GlobalChatRoom = () => {
                 <p>공지</p>
                 <ArrowDownIcon width={14} height={7} />
               </div>
-              {isNoticeOpened && (
-                <div css={s.noticeContentStyle}>
-                  처음 오신 분들은 공지를 꼭 읽어주시길 바랍니다. 상대방을 향한 비방, 욕설글은 정지 대상이 될 수
-                  있습니다. 이 점 유의하여 올바른 서비스 사용을 해주시길 바랍니다. 모든 유저가 행복한 채팅 환경을
-                  조성해주시길 바랍니다.
-                </div>
-              )}
+              {isNoticeOpened && <div css={s.noticeContentStyle}>{CHAT_NOTICE_DEFAULT}</div>}
             </div>
           </div>
         </div>

--- a/src/pages/GroupChatListPage/GroupChatListPage.tsx
+++ b/src/pages/GroupChatListPage/GroupChatListPage.tsx
@@ -22,7 +22,7 @@ const GroupChatListPage = () => {
     sort: GROUP_SORTING_OPTIONS[0].id,
     scope: "",
     keyword: "",
-    tagList: [],
+    tags: [],
   });
 
   const { data } = useSearch({

--- a/src/pages/GroupChatListPage/GroupChatListPage.tsx
+++ b/src/pages/GroupChatListPage/GroupChatListPage.tsx
@@ -1,21 +1,47 @@
 import { AddButton, SearchLayout, TitleContainer } from "@/components";
+import { useSearch } from "@/components/SearchLayout/hooks/useSearch";
+import type { QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
 import { SORTING_OPTIONS } from "@/constants/dropdown";
-import { HASH_TAGS_DUMMY } from "@/constants/hashTagsDummy";
 import { useState } from "react";
+import { useLocation, useParams } from "react-router-dom";
 import * as s from "./GroupChatListPage.styles";
 import AddGroupChatModal from "./components/AddGroupChatModal/AddGroupChatModal";
 import GroupChatListAll from "./components/GroupChatListAll/GroupChatListAll";
 
 const GroupChatListPage = () => {
+  const location = useLocation();
+
+  const { serverId: param } = useParams();
+  const serverId = Number(param);
+
   const [sortingOption, setSortingOption] = useState(SORTING_OPTIONS[0]);
-  const [keyword, setKeyword] = useState("");
   const [isVisible, setIsVisible] = useState(false);
+
+  const hashTagData = location.state?.hashTagData || [];
+  console.log(hashTagData);
+
+  const [queryParam, setQueryParam] = useState<QueryParamTypes>({
+    page: 0,
+    sort: "",
+    scope: "",
+    keyword: "",
+    tagList: [],
+  });
+
+  const { data } = useSearch({
+    serverId,
+    type: "groups",
+    queryParam,
+  });
+  console.log(data);
+
+  // useEffect(() => console.log(queryParam), [setQueryParam]);
 
   return (
     <div css={s.layoutStyle}>
       <AddGroupChatModal isVisible={isVisible} setIsVisible={setIsVisible} />
       <AddButton setIsModalVisible={setIsVisible} />
-      <SearchLayout keyword={keyword} setKeyword={setKeyword} hashTagData={HASH_TAGS_DUMMY} />
+      <SearchLayout queryParam={queryParam} setQueryParam={setQueryParam} hashTagData={hashTagData} />
 
       <TitleContainer
         title="그룹 채팅방"
@@ -23,7 +49,7 @@ const GroupChatListPage = () => {
         sortingOption={sortingOption}
         setSortingOption={setSortingOption}
       >
-        <GroupChatListAll />
+        {data && <GroupChatListAll serverId={serverId} data={data} />}
       </TitleContainer>
     </div>
   );

--- a/src/pages/GroupChatListPage/GroupChatListPage.tsx
+++ b/src/pages/GroupChatListPage/GroupChatListPage.tsx
@@ -1,7 +1,7 @@
 import { AddButton, SearchLayout, TitleContainer } from "@/components";
 import { useSearch } from "@/components/SearchLayout/hooks/useSearch";
 import type { QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
-import { SORTING_OPTIONS } from "@/constants/dropdown";
+import { GROUP_SORTING_OPTIONS } from "@/constants/dropdown";
 import { useState } from "react";
 import { useLocation, useParams } from "react-router-dom";
 import * as s from "./GroupChatListPage.styles";
@@ -9,20 +9,17 @@ import AddGroupChatModal from "./components/AddGroupChatModal/AddGroupChatModal"
 import GroupChatListAll from "./components/GroupChatListAll/GroupChatListAll";
 
 const GroupChatListPage = () => {
-  const location = useLocation();
+  const [isVisible, setIsVisible] = useState(false);
 
   const { serverId: param } = useParams();
   const serverId = Number(param);
 
-  const [sortingOption, setSortingOption] = useState(SORTING_OPTIONS[0]);
-  const [isVisible, setIsVisible] = useState(false);
-
+  const location = useLocation();
   const hashTagData = location.state?.hashTagData || [];
-  console.log(hashTagData);
 
   const [queryParam, setQueryParam] = useState<QueryParamTypes>({
     page: 0,
-    sort: "",
+    sort: GROUP_SORTING_OPTIONS[0].id,
     scope: "",
     keyword: "",
     tagList: [],
@@ -33,9 +30,6 @@ const GroupChatListPage = () => {
     type: "groups",
     queryParam,
   });
-  console.log(data);
-
-  // useEffect(() => console.log(queryParam), [setQueryParam]);
 
   return (
     <div css={s.layoutStyle}>
@@ -45,9 +39,9 @@ const GroupChatListPage = () => {
 
       <TitleContainer
         title="그룹 채팅방"
-        sortingOptions={SORTING_OPTIONS}
-        sortingOption={sortingOption}
-        setSortingOption={setSortingOption}
+        sortingOptions={GROUP_SORTING_OPTIONS}
+        sortingOption={GROUP_SORTING_OPTIONS.find((option) => option.id === queryParam.sort)}
+        setSortingOption={(newOpt) => setQueryParam((prev) => ({ ...prev, sort: newOpt.id }))}
       >
         {data && <GroupChatListAll serverId={serverId} data={data} />}
       </TitleContainer>

--- a/src/pages/GroupChatListPage/components/GroupChatListAll/GroupChatListAll.tsx
+++ b/src/pages/GroupChatListPage/components/GroupChatListAll/GroupChatListAll.tsx
@@ -2,18 +2,16 @@ import rotateLogoImg from "@/assets/img/rotateLogoImg.png";
 import { RotateLogoIcon } from "@/assets/svg";
 import { DetailModal, NoDataContainer } from "@/components";
 
-import { useFetchGroupChatList } from "@/pages/GroupChatListPage/hooks/useFetchGroupChatList";
 import type { GroupChatListResponse } from "@/pages/GroupChatListPage/types/groupChatTypes";
 import { useState } from "react";
-import { useLocation } from "react-router-dom";
 import * as s from "./GroupChatListAll.styles";
 
-const GroupChatListAll = () => {
-  const { pathname } = useLocation();
-  const serverId = Number(pathname.split("/")[1]);
+interface GroupChatListAllProps {
+  serverId: number;
+  data: GroupChatListResponse;
+}
 
-  const { data } = useFetchGroupChatList(serverId) as { data?: GroupChatListResponse };
-
+const GroupChatListAll = ({ serverId, data }: GroupChatListAllProps) => {
   const items = data?.result.chatRoomList ?? [];
   const itemCount = data?.result.pageInfo?.totalElements ?? 0;
 

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,4 +1,5 @@
 import { DetailModal, SearchLayout, TitleContainer } from "@/components";
+import type { QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
 import CoffeeChatList from "@/pages/CoffeeChatListPage/components/CoffeeChatList/CoffeeChatList";
 import GroupChatList from "@/pages/GroupChatListPage/components/GroupChatList/GroupChatList";
 import GlobalChatPreview from "@/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview";
@@ -11,11 +12,18 @@ const HomePage = () => {
   const navigate = useNavigate();
   const globalServer = useGlobalServer();
 
-  const [keyword, setKeyword] = useState("");
   const [isVisible, setIsVisible] = useState(false);
   const [selectedItem, setSelectedItem] = useState<{ id: string | null; type: string | null }>({
     id: null,
     type: null,
+  });
+
+  const [queryParam, setQueryParam] = useState<QueryParamTypes>({
+    page: 0,
+    sort: "",
+    scope: "",
+    keyword: "",
+    tagList: [],
   });
 
   const serverId = Number(globalServer?.id);
@@ -48,19 +56,18 @@ const HomePage = () => {
           data={selectedChat}
           serverId={serverId}
           selectedItemId={Number(selectedItem.id)}
-          isVisible={true}
           setIsVisible={() => setSelectedItem({ type: null, id: null })}
         />
       )}
 
       <div css={s.layoutStyle}>
         <div css={s.leftLayoutStyle}>
-          <SearchLayout keyword={keyword} setKeyword={setKeyword} hashTagData={hashTagList} />
+          <SearchLayout queryParam={queryParam} setQueryParam={setQueryParam} hashTagData={hashTagList} />
           <TitleContainer
             title="그룹 채팅방"
             textButton="전체보기"
             handleTextButtonClick={() => {
-              navigate("./group-chat-list");
+              navigate("./group-chat-list", { state: { hashTagData: hashTagList } });
             }}
           >
             <GroupChatList data={groupChatRoom} handleItemClick={handleItemClick} />

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -76,7 +76,7 @@ const HomePage = () => {
             title="오프라인 커피챗"
             textButton="전체보기"
             handleTextButtonClick={() => {
-              navigate("./tea-time-list");
+              navigate("./tea-time-list", { state: { hashTagData: hashTagList } });
             }}
             css={{ paddingBottom: "5rem" }}
           >

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -4,13 +4,12 @@ import CoffeeChatList from "@/pages/CoffeeChatListPage/components/CoffeeChatList
 import GroupChatList from "@/pages/GroupChatListPage/components/GroupChatList/GroupChatList";
 import GlobalChatPreview from "@/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview";
 import { useHomeData } from "@/pages/HomePage/hooks/useHomeData";
-import { useGlobalServer } from "@/stores/useGlobalServerStore";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import * as s from "./HomePage.styles";
 const HomePage = () => {
   const navigate = useNavigate();
-  const globalServer = useGlobalServer();
+  const param = useParams();
 
   const [isVisible, setIsVisible] = useState(false);
   const [selectedItem, setSelectedItem] = useState<{ id: string | null; type: string | null }>({
@@ -26,8 +25,9 @@ const HomePage = () => {
     tagList: [],
   });
 
-  const serverId = Number(globalServer?.id);
+  const serverId = Number(param.serverId);
   const { data: homeData, isLoading } = useHomeData(serverId);
+  console.log(homeData);
 
   if (isLoading) return <div>로딩 중...</div>;
   if (!homeData) return <div>데이터 없음</div>;

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -22,7 +22,7 @@ const HomePage = () => {
     sort: "",
     scope: "",
     keyword: "",
-    tagList: [],
+    tags: [],
   });
 
   const serverId = Number(param.serverId);

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -27,7 +27,6 @@ const HomePage = () => {
 
   const serverId = Number(param.serverId);
   const { data: homeData, isLoading } = useHomeData(serverId);
-  console.log(homeData);
 
   if (isLoading) return <div>로딩 중...</div>;
   if (!homeData) return <div>데이터 없음</div>;

--- a/src/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview.tsx
+++ b/src/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview.tsx
@@ -1,5 +1,6 @@
 import { PinIcon } from "@/assets/svg";
 import { Button } from "@/components";
+import { SINGLE_LINE_NOTICE_DEFAULT } from "@/pages/HomePage/constants/noticeDummy";
 import type { HomeDataTypes } from "@/pages/HomePage/types/homeDataTypes";
 import * as s from "./GlobalChatPreview.styles";
 
@@ -14,10 +15,10 @@ const GlobalChatPreview = ({ notice, chat }: GlobalChatPreviewProps) => {
       <div css={s.noticeStyle}>
         <PinIcon width={10} height={13} />
         <p>[공지필독]</p>
-        <p>{notice.pageInfo.totalElements > 0 ? notice.noticeList[0].title : "공지사항이 없습니다."}</p>
+        <p>{notice?.pageInfo.totalElements ? notice.noticeList[0].title : SINGLE_LINE_NOTICE_DEFAULT}</p>
       </div>
       <div css={s.chatStyle}>
-        {chat.chatList.slice(0, 6).map((chat) => {
+        {chat?.chatList.slice(0, 6).map((chat) => {
           return (
             <div css={s.chatBarStyle} key={chat.id}>
               <Button variant="tertiary" size="medium">

--- a/src/pages/HomePage/constants/noticeDummy.ts
+++ b/src/pages/HomePage/constants/noticeDummy.ts
@@ -1,0 +1,4 @@
+export const SINGLE_LINE_NOTICE_DEFAULT = "공지사항이 없습니다.";
+
+export const CHAT_NOTICE_DEFAULT = `처음 오신 분들은 공지를 꼭 읽어주시길 바랍니다. 상대방을 향한 비방, 욕설글은 정지 대상이 될 수 있습니다.
+이 점 유의하여 올바른 서비스 사용을 해주시길 바랍니다. 모든 유저가 행복한 채팅 환경을 조성해주시길 바랍니다.`;

--- a/src/pages/HomePage/types/homeDataTypes.ts
+++ b/src/pages/HomePage/types/homeDataTypes.ts
@@ -67,16 +67,17 @@ export type HomeDataTypes = {
   };
   notice: {
     pageInfo: PageInfoTypes;
-    noticeList: {
-      id: number;
-      title: string;
-      content: string;
-    }[];
-  };
+    noticeList:
+      | {
+          id: number;
+          title: string;
+          content: string;
+        }[];
+  } | null;
   chat: {
     pageInfo: PageInfoTypes;
     chatList: ChatTypes[];
-  };
+  } | null;
 };
 
 export type HomeResponseTypes = {


### PR DESCRIPTION
## 🎯 관련 이슈

close #103 

<br />

## 🚀 작업 내용
- 검색 API 연결
  - 해시태그 클릭 시 `tagList` 쿼리 파라미터에 추가되고, 두 번 클릭 시 삭제됨
  - 검색어 입력 시 디바운스 후에 `keyword` 쿼리 파라미터 업데이트
  - 정렬 옵션 클릭 시 `sort` 쿼리 파라미터 업데이트
  - 쿼리 파라미터 상태변수를 url화 하여 api 호출

<img width="1002" alt="스크린샷 2025-03-20 오후 10 51 03" src="https://github.com/user-attachments/assets/8907ad61-1211-4559-97a8-ecdf2c09061d" />

```
export interface QueryParamTypes {
  page: number;
  sort: string;
  scope: "joined" | "owner" | "";
  keyword: string;
  tagList: string[];
}

export interface SearchParamTypes {
  serverId: number;
  type: string;
  queryParam: QueryParamTypes;
}
```

```
const [queryParam, setQueryParam] = useState<QueryParamTypes>({
  page: 0,
  sort: GROUP_SORTING_OPTIONS[0].id,
  scope: "",
  keyword: "",
  tagList: [],
});
```

쿼리 파라미터는 위와 같은 객체 형태의 상태변수로 관리

<br />


## 📸 스크린샷

| <img width="600" alt="image" src="https://github.com/user-attachments/assets/840ea5ae-a816-411b-82cc-5498e1992b75" /> |
| :---------------------: |
| 검색어 입력 시 |

| <img width="600" alt="image" src="https://github.com/user-attachments/assets/408b4133-8cf3-4d8d-9f59-43c269eda048" /> |
| :---------------------: |
| 해시태그 선택 |

| <img width="600" alt="image" src="https://github.com/user-attachments/assets/7f7a9a04-d671-4de5-8d7c-ed8829f3848d" /> |
| :---------------------: |
| 정렬 옵션 '이름순' |

<br />


<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?
- 티타임이 정렬 옵션에는 "마감 임박순" 옵션이 필요없을 것 같아, `GROUP_SORTING_OPTIONS`와 MEETING_SORTING_OPTIONS`를 분리했습니다! 
- 현재 검색 기능이 잘 안 되는 문제가 있는데, 백에서 수정이 필요한 부분들이라 디코에 남겨뒀습니다! 리뷰 시 참고해주세요.

<br />
