### PR TITLE
#101 [FEAT] 네이버 소셜 로그인 구현

### DIFF
--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -2,6 +2,7 @@ export const PATH = {
   ONBOARDING: "/",
   SIGNUP: "/signup",
   KAKAO: "/redirect-kakao",
+  NAVER: "/redirect-naver",
 
   DM: "/dm",
   MYPAGE: "/mypage",

--- a/src/pages/OnboardingPage/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage/OnboardingPage.tsx
@@ -3,12 +3,16 @@ import logo2Img from "@/assets/img/logo2Img.png";
 import { GoogleIcon, KakaoIcon, Logo4WhiteIcon, NaverIcon } from "@/assets/svg";
 import AuthContainer from "@/components/AuthContainer/AuthContainer";
 import * as s from "@/pages/OnboardingPage/OnboardingPage.styles";
-import { KAKAO_URL } from "@/pages/OnboardingPage/constants";
+import { KAKAO_URL, NAVER_URL } from "@/pages/OnboardingPage/constants";
 import { logo1Style, logo2Style, wrapperStyle } from "@/pages/SignupPage/SignupPage.styles";
 
 const OnBoardingPage = () => {
   const handleKakaoLogin = () => {
     window.location.href = KAKAO_URL;
+  };
+
+  const handleNaverLogin = () => {
+    window.location.href = NAVER_URL;
   };
 
   return (
@@ -37,7 +41,12 @@ const OnBoardingPage = () => {
             <KakaoIcon width={21} height={19} />
             카카오로 시작하기
           </button>
-          <button type="button" aria-label="네이버로 시작하기" css={[s.commonBtnStyle, s.naverBtnStyle]}>
+          <button
+            type="button"
+            aria-label="네이버로 시작하기"
+            css={[s.commonBtnStyle, s.naverBtnStyle]}
+            onClick={handleNaverLogin}
+          >
             <NaverIcon width={19} height={18} />
             네이버로 시작하기
           </button>

--- a/src/pages/OnboardingPage/apis/fetchNaverLogin.ts
+++ b/src/pages/OnboardingPage/apis/fetchNaverLogin.ts
@@ -1,0 +1,8 @@
+import { instance } from "@/apis/instance";
+import type { LoginResponseTypes } from "@/pages/OnboardingPage/types";
+
+export const fetchNaverLogin = async (code: string) => {
+  const response = await instance.get<LoginResponseTypes>(`api/v1/login/naver-callback?code=${code}`).json();
+
+  return response;
+};

--- a/src/pages/OnboardingPage/components/KakaoLogin/KakaoLogin.tsx
+++ b/src/pages/OnboardingPage/components/KakaoLogin/KakaoLogin.tsx
@@ -1,29 +1,13 @@
-import { fetchMyServers } from "@/components/ServerHeader/apis/server";
-import { PATH } from "@/constants/path";
 import { useKakaoLogin } from "@/pages/OnboardingPage/hooks/useKakaoLogin";
-import { useCallback, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useRedirectToServer } from "@/pages/OnboardingPage/hooks/useRedirectToServer";
+import { useEffect } from "react";
 
 const KakaoLogin = () => {
-  const navigate = useNavigate();
   const code = new URL(window.location.href).searchParams.get("code") || "";
 
   const { data, isSuccess } = useKakaoLogin(code);
 
-  const redirectToFirstServer = useCallback(async () => {
-    try {
-      const myServers = await fetchMyServers();
-
-      if (myServers?.result.count > 0) {
-        const firstServerId = myServers.result.serverList[0].id;
-        navigate(PATH.HOME.replace(":serverId", String(firstServerId)));
-      } else {
-        navigate(PATH.SIGNUP);
-      }
-    } catch (error) {
-      navigate(PATH.SIGNUP);
-    }
-  }, [navigate]);
+  const handleRedirect = useRedirectToServer();
 
   useEffect(() => {
     if (isSuccess && data) {
@@ -32,9 +16,9 @@ const KakaoLogin = () => {
 
       localStorage.setItem("userId", data.result.userId.toString());
 
-      redirectToFirstServer();
+      handleRedirect();
     }
-  }, [data, isSuccess, redirectToFirstServer]);
+  }, [data, isSuccess, handleRedirect]);
 
   return <div>로딩 중</div>;
 };

--- a/src/pages/OnboardingPage/components/NaverLogin/NaverLogin.tsx
+++ b/src/pages/OnboardingPage/components/NaverLogin/NaverLogin.tsx
@@ -1,0 +1,26 @@
+import { useNaverLogin } from "@/pages/OnboardingPage/hooks/useNaverLogin";
+import { useRedirectToServer } from "@/pages/OnboardingPage/hooks/useRedirectToServer";
+import { useEffect } from "react";
+
+const NaverLogin = () => {
+  const code = new URL(window.location.href).searchParams.get("code") || "";
+
+  const { data, isSuccess } = useNaverLogin(code);
+
+  const handleRedirect = useRedirectToServer();
+
+  useEffect(() => {
+    if (isSuccess && data) {
+      localStorage.setItem("accessToken", data.result.accessToken);
+      localStorage.setItem("refreshToken", data.result.refreshToken);
+
+      localStorage.setItem("userId", data.result.userId.toString());
+
+      handleRedirect();
+    }
+  }, [data, isSuccess, handleRedirect]);
+
+  return <div>로딩 중</div>;
+};
+
+export default NaverLogin;

--- a/src/pages/OnboardingPage/constants/index.ts
+++ b/src/pages/OnboardingPage/constants/index.ts
@@ -1,3 +1,4 @@
 export const KAKAO_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${import.meta.env.VITE_KAKAO_API_KEY}&redirect_uri=${import.meta.env.VITE_KAKAO_REDIRECT_URL}`;
+export const NAVER_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${import.meta.env.VITE_NAVER_API_KEY}&redirect_url=${import.meta.env.VITE_NAVER_REDIRECT_URL}&state=STATE_STRING`;
 
 export const RETRY_COUNT = 3;

--- a/src/pages/OnboardingPage/hooks/useNaverLogin.ts
+++ b/src/pages/OnboardingPage/hooks/useNaverLogin.ts
@@ -1,0 +1,10 @@
+import { fetchNaverLogin } from "@/pages/OnboardingPage/apis/fetchNaverLogin";
+import { useQuery } from "@tanstack/react-query";
+
+export const useNaverLogin = (code: string) => {
+  return useQuery({
+    queryKey: ["naver-login", code],
+    queryFn: () => fetchNaverLogin(code),
+    enabled: !!code,
+  });
+};

--- a/src/pages/OnboardingPage/hooks/useRedirectToServer.ts
+++ b/src/pages/OnboardingPage/hooks/useRedirectToServer.ts
@@ -1,0 +1,25 @@
+import { fetchMyServers } from "@/components/ServerHeader/apis/server";
+import { PATH } from "@/constants/path";
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const useRedirectToServer = () => {
+  const navigate = useNavigate();
+
+  const handleRedirect = useCallback(async () => {
+    try {
+      const myServers = await fetchMyServers();
+
+      if (myServers?.result.count > 0) {
+        const firstServerId = myServers.result.serverList[0].id;
+        navigate(PATH.HOME.replace(":serverId", String(firstServerId)));
+      } else {
+        navigate(PATH.SIGNUP);
+      }
+    } catch (error) {
+      navigate(PATH.SIGNUP);
+    }
+  }, [navigate]);
+
+  return handleRedirect;
+};

--- a/src/routers/Router.tsx
+++ b/src/routers/Router.tsx
@@ -5,6 +5,7 @@ import { CoffeeChatListPage, DMPage, GroupChatListPage, HomePage, MyPage, Onboar
 import ChatPage from "@/pages/ChatPage/ChatPage";
 import GlobalChatPage from "@/pages/GlobalChatPage/GlobalChatPage";
 import KakaoLogin from "@/pages/OnboardingPage/components/KakaoLogin/KakaoLogin";
+import NaverLogin from "@/pages/OnboardingPage/components/NaverLogin/NaverLogin";
 import CareerAdd from "@/pages/UserSettingPage/components/CareerAdd/CareerAdd";
 import CareerEdit from "@/pages/UserSettingPage/components/CareerEdit/CareerEdit";
 import CareerSettingList from "@/pages/UserSettingPage/components/CareerSettingList/CareerSettingList";
@@ -37,6 +38,10 @@ export const router = createBrowserRouter([
       {
         path: PATH.KAKAO,
         element: <KakaoLogin />,
+      },
+      {
+        path: PATH.NAVER,
+        element: <NaverLogin />,
       },
     ],
   },


### PR DESCRIPTION
## 🎯 관련 이슈

close #101 

<br />

## 🚀 작업 내용

- 네이버 소셜로그인 구현

<br />

<!--
## 📸 스크린샷

| (스크린샷을 넣어주세요) |
| :---------------------: |

<br />
-->

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->


## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- 카카오 로그인과 거의 똑같게 구현했습니다 env파일 따로 전달해드릴게요 !
- redirectToFirstServer의 경우 소셜 로그인 로직에 다 필요한 로직이라 커스텀 훅으로 분리했습니다.

<br />

