### PR TITLE
 #115 [FEAT] 서버 id 전역으로 관리

### DIFF
--- a/src/components/ServerHeader/hooks/useServerList.ts
+++ b/src/components/ServerHeader/hooks/useServerList.ts
@@ -1,6 +1,6 @@
 import { fetchAllServers, fetchMyServers } from "@/components/ServerHeader/apis/server";
 import type { ServerResponseTypes } from "@/components/ServerHeader/types/serverTypes";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 
 export const useAllServerList = () => {
   return useQuery<ServerResponseTypes>({
@@ -12,7 +12,7 @@ export const useAllServerList = () => {
 };
 
 export const useMyServerList = () => {
-  return useQuery<ServerResponseTypes>({
+  return useSuspenseQuery<ServerResponseTypes>({
     queryKey: ["myServerInfo"],
     queryFn: fetchMyServers as () => Promise<ServerResponseTypes>,
     staleTime: 1000 * 60 * 10,

--- a/src/hooks/useInitializeServerId.tsx
+++ b/src/hooks/useInitializeServerId.tsx
@@ -1,0 +1,31 @@
+import { useMyServerList } from "@/components/ServerHeader/hooks/useServerList";
+import { PATH } from "@/constants/path";
+import { useServerId, useServerIdAction } from "@/stores/useServerId";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const useInitializeServerId = () => {
+  const serverId = useServerId();
+  const { setServerId } = useServerIdAction();
+
+  const navigate = useNavigate();
+
+  const { data, isSuccess } = useMyServerList();
+
+  useEffect(() => {
+    if (isSuccess) {
+      if (data.result.serverList.length === 0) {
+        navigate(PATH.ONBOARDING);
+
+        return;
+      }
+      const serverId = data.result.serverList[0].id;
+
+      setServerId(serverId);
+    } else if (!isSuccess) {
+      navigate(PATH.ONBOARDING);
+    }
+  });
+
+  return serverId;
+};

--- a/src/pages/OnboardingPage/components/KakaoLogin/KakaoLogin.tsx
+++ b/src/pages/OnboardingPage/components/KakaoLogin/KakaoLogin.tsx
@@ -18,22 +18,17 @@ const KakaoLogin = () => {
 
     const { accessToken, refreshToken, userId, newUser } = data.result;
 
-    if (!accessToken || !refreshToken || userId == null) return;
-
     localStorage.setItem("accessToken", accessToken);
     localStorage.setItem("refreshToken", refreshToken);
-    localStorage.setItem("userId", userId.toString());
 
-    console.log(newUser);
+    localStorage.setItem("userId", userId.toString());
 
     if (newUser) {
       navigate(PATH.SIGNUP);
     } else {
       if (serverId) {
-        console.log(serverId);
         navigate(PATH.HOME.replace(":serverId", serverId.toString()));
       }
-      console.log(serverId);
     }
   }, [data, isSuccess, serverId]);
 

--- a/src/pages/OnboardingPage/components/KakaoLogin/KakaoLogin.tsx
+++ b/src/pages/OnboardingPage/components/KakaoLogin/KakaoLogin.tsx
@@ -1,23 +1,41 @@
+import { PATH } from "@/constants/path";
+import { useInitializeServerId } from "@/hooks/useInitializeServerId";
 import { useKakaoLogin } from "@/pages/OnboardingPage/hooks/useKakaoLogin";
-import { useRedirectToServer } from "@/pages/OnboardingPage/hooks/useRedirectToServer";
 import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 const KakaoLogin = () => {
-  const code = new URL(window.location.href).searchParams.get("code") || "";
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const code = searchParams.get("code") || "";
 
   const { data, isSuccess } = useKakaoLogin(code);
+  const serverId = useInitializeServerId();
 
-  const handleRedirect = useRedirectToServer();
-
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
-    if (isSuccess && data) {
-      localStorage.setItem("accessToken", data.result.accessToken);
-      localStorage.setItem("refreshToken", data.result.refreshToken);
-      localStorage.setItem("userId", data.result.userId.toString());
+    if (!isSuccess || !data) return;
 
-      handleRedirect();
+    const { accessToken, refreshToken, userId, newUser } = data.result;
+
+    if (!accessToken || !refreshToken || userId == null) return;
+
+    localStorage.setItem("accessToken", accessToken);
+    localStorage.setItem("refreshToken", refreshToken);
+    localStorage.setItem("userId", userId.toString());
+
+    console.log(newUser);
+
+    if (newUser) {
+      navigate(PATH.SIGNUP);
+    } else {
+      if (serverId) {
+        console.log(serverId);
+        navigate(PATH.HOME.replace(":serverId", serverId.toString()));
+      }
+      console.log(serverId);
     }
-  }, [data, isSuccess, handleRedirect]);
+  }, [data, isSuccess, serverId]);
 
   return <div>로딩 중</div>;
 };

--- a/src/pages/OnboardingPage/components/NaverLogin/NaverLogin.tsx
+++ b/src/pages/OnboardingPage/components/NaverLogin/NaverLogin.tsx
@@ -1,26 +1,37 @@
+import { PATH } from "@/constants/path";
+import { useInitializeServerId } from "@/hooks/useInitializeServerId";
 import { useNaverLogin } from "@/pages/OnboardingPage/hooks/useNaverLogin";
-import { useRedirectToServer } from "@/pages/OnboardingPage/hooks/useRedirectToServer";
 import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 const NaverLogin = () => {
-  const code = new URL(window.location.href).searchParams.get("code") || "";
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const code = searchParams.get("code") || "";
 
   const { data, isSuccess } = useNaverLogin(code);
+  const serverId = useInitializeServerId();
 
-  const handleRedirect = useRedirectToServer();
-
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
-    if (isSuccess && data) {
-      localStorage.setItem("accessToken", data.result.accessToken);
-      localStorage.setItem("refreshToken", data.result.refreshToken);
+    if (!isSuccess || !data) return;
 
-      localStorage.setItem("userId", data.result.userId.toString());
+    const { accessToken, refreshToken, userId, newUser } = data.result;
 
-      handleRedirect();
+    if (!accessToken || !refreshToken || userId == null) return;
+
+    localStorage.setItem("accessToken", accessToken);
+    localStorage.setItem("refreshToken", refreshToken);
+    localStorage.setItem("userId", userId.toString());
+
+    if (newUser) {
+      navigate(PATH.SIGNUP);
+    } else {
+      if (serverId) navigate(PATH.HOME.replace(":serverId", serverId.toString()));
     }
-  }, [data, isSuccess, handleRedirect]);
+  }, [data, isSuccess, serverId]);
 
-  return <div>로딩 중</div>;
+  return <div>로딩 중...</div>;
 };
 
 export default NaverLogin;

--- a/src/pages/OnboardingPage/components/NaverLogin/NaverLogin.tsx
+++ b/src/pages/OnboardingPage/components/NaverLogin/NaverLogin.tsx
@@ -5,33 +5,32 @@ import { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 const NaverLogin = () => {
-  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const code = searchParams.get("code") || "";
+
+  const navigate = useNavigate();
 
   const { data, isSuccess } = useNaverLogin(code);
   const serverId = useInitializeServerId();
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
-    if (!isSuccess || !data) return;
+    if (!isSuccess && !data) return;
 
     const { accessToken, refreshToken, userId, newUser } = data.result;
 
-    if (!accessToken || !refreshToken || userId == null) return;
-
     localStorage.setItem("accessToken", accessToken);
     localStorage.setItem("refreshToken", refreshToken);
+
     localStorage.setItem("userId", userId.toString());
 
     if (newUser) {
       navigate(PATH.SIGNUP);
     } else {
-      if (serverId) navigate(PATH.HOME.replace(":serverId", serverId.toString()));
+      navigate(PATH.HOME.replace(":serverId", serverId.toString()));
     }
-  }, [data, isSuccess, serverId]);
+  }, [data, isSuccess, navigate, serverId]);
 
-  return <div>로딩 중...</div>;
+  return <div>로딩 중</div>;
 };
 
 export default NaverLogin;

--- a/src/pages/SignupPage/components/InfoStep/InfoStep.tsx
+++ b/src/pages/SignupPage/components/InfoStep/InfoStep.tsx
@@ -11,7 +11,7 @@ interface InfoStepProps {
 const InfoStep = ({ onNext }: InfoStepProps) => {
   const { handleInfoChange, form, isNickNameError } = useInfoForm();
 
-  const isButtonDisabled = !form.name || isNickNameError;
+  const isButtonDisabled = !form.nickname;
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -21,15 +21,13 @@ const InfoStep = ({ onNext }: InfoStepProps) => {
   return (
     <form onSubmit={handleSubmit} css={{ zIndex: 1 }}>
       <AuthContainer title={TITLE.PROFILE} desc={DESC.BASIC_INFO}>
-        <Input placeholder={PLACEHOLDER.NAME} onChange={(e) => handleInfoChange(e, "name")} value={form.name} />
         <Input
-          placeholder={PLACEHOLDER.NICKNAME}
+          placeholder={PLACEHOLDER.NAME}
           onChange={(e) => handleInfoChange(e, "nickname")}
           value={form.nickname}
           isError={isNickNameError}
           supportingText={SUPPORTING_TEXT.NICKNAME}
         />
-
         <Button type="submit" disabled={isButtonDisabled} css={{ marginTop: "8.1rem" }}>
           다음
         </Button>

--- a/src/pages/SignupPage/types/signupFormTypes.ts
+++ b/src/pages/SignupPage/types/signupFormTypes.ts
@@ -1,5 +1,4 @@
 export interface SignUpFormTypes {
-  name?: string;
   nickname: string;
   urlList: string[];
   headline: string;

--- a/src/routers/Router.tsx
+++ b/src/routers/Router.tsx
@@ -29,11 +29,19 @@ export const router = createBrowserRouter([
     children: [
       {
         path: PATH.ONBOARDING,
-        element: <OnboardingPage />,
+        element: (
+          <Suspense>
+            <OnboardingPage />
+          </Suspense>
+        ),
       },
       {
         path: PATH.SIGNUP,
-        element: <SignupPage />,
+        element: (
+          <Suspense>
+            <SignupPage />
+          </Suspense>
+        ),
       },
       {
         path: PATH.KAKAO,

--- a/src/stores/useServerId.ts
+++ b/src/stores/useServerId.ts
@@ -1,22 +1,19 @@
-import { useMyServerList } from "@/components/ServerHeader/hooks/useServerList";
 import { create } from "zustand";
 
 type ServerStore = {
-  serverId: number | null;
+  serverId: number;
   actions: {
     setServerId: (id: number | null) => void;
   };
 };
 
-const server = useMyServerList();
-
 const useServerIdStore = create<ServerStore>((set) => ({
-  serverId: Number(server.data?.result.serverList[0].id),
+  serverId: 0,
 
   actions: {
     setServerId: (serverId: number | null) =>
       set({
-        serverId,
+        serverId: serverId ?? 0,
       }),
   },
 }));

--- a/src/stores/useServerId.ts
+++ b/src/stores/useServerId.ts
@@ -1,0 +1,25 @@
+import { useMyServerList } from "@/components/ServerHeader/hooks/useServerList";
+import { create } from "zustand";
+
+type ServerStore = {
+  serverId: number | null;
+  actions: {
+    setServerId: (id: number | null) => void;
+  };
+};
+
+const server = useMyServerList();
+
+const useServerIdStore = create<ServerStore>((set) => ({
+  serverId: Number(server.data?.result.serverList[0].id),
+
+  actions: {
+    setServerId: (serverId: number | null) =>
+      set({
+        serverId,
+      }),
+  },
+}));
+
+export const useServerId = () => useServerIdStore((state) => state.serverId);
+export const useServerIdAction = () => useServerIdStore((state) => state.actions);


### PR DESCRIPTION
## 🎯 관련 이슈

close #115 

<br />

## 🚀 작업 내용

- 서버 id zustand를 사용한 전역 상태로 관리
- 회원가입이 이미 완료된 경우(newUser flag확인) 갖고있는 serverLIst 중 첫 번째 값으로 serverId설정, 라우팅
- 회원가입 뷰 닉네임 input 제거 

<br />




## 🔎 발견된 장애가 있었나요?

- 전역으로 관리하는 serverId의 경우 api에서 가져오는 값이기 때문에 값이 undefined가 될 수 있기 때문에
useSuspenseQuery로 데이터를 받아와서 값이 undefined가 되지 않도록 수정했습니다.

<br />

 
## 📸 스크린샷

https://github.com/user-attachments/assets/537b8b3a-cac1-44fc-ba9c-ff4f54bd9368

<img width="892" alt="스크린샷 2025-03-23 오후 4 52 03" src="https://github.com/user-attachments/assets/3c0c4602-a558-4172-bbf2-edc60e780c93" />


<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
