### PR TITLE
#117 [FEAT] userId 전역상태로 관리

### DIFF
--- a/src/hooks/useInitializeUserId.ts
+++ b/src/hooks/useInitializeUserId.ts
@@ -1,0 +1,24 @@
+import { PATH } from "@/constants/path";
+import { useUserId, useUserIdAction } from "@/stores/useUserId";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const useInitializeUserId = () => {
+  const navigate = useNavigate();
+
+  const userId = useUserId();
+  const { setUserId } = useUserIdAction();
+
+  useEffect(() => {
+    const userId = localStorage.getItem("userId");
+
+    if (!userId) {
+      console.warn("userId 없음");
+      navigate(PATH.ONBOARDING);
+    } else {
+      setUserId(+userId);
+    }
+  }, [navigate, setUserId]);
+
+  return userId;
+};

--- a/src/pages/ChatPage/components/ChatRoom/ChatRoom.tsx
+++ b/src/pages/ChatPage/components/ChatRoom/ChatRoom.tsx
@@ -11,6 +11,7 @@ import { useChatStompClient } from "@/pages/ChatPage/hooks/useGroupChatStompClie
 import { useUpdateChatLogs } from "@/pages/ChatPage/hooks/useUpdateChatLogs";
 import type { ChatTypes } from "@/pages/ChatPage/types/groupChatLogTypes";
 import { useMenuBarAction, useMenuBarIsOpen } from "@/stores/useMenuBarStore";
+import { useUserId } from "@/stores/useUserId";
 import { chatFormatTime } from "@/utils/dateTime";
 import * as s from "@pages/ChatPage/components/ChatRoom/ChatRoom.styles";
 import { useEffect, useState } from "react";
@@ -32,7 +33,8 @@ const ChatRoom = ({ menu, type, serverId, selectedRoomId, title }: ChatRoomProps
 
   const stompClient = useChatStompClient(selectedRoomId, setLogs);
   const scrollRef = useScrollToBottom();
-  const myId = Number(localStorage.getItem("userId")) || null;
+
+  const myId = useUserId();
 
   useUpdateChatLogs(serverId, type, selectedRoomId, setLogs);
   useChatScroll(scrollRef, logs);

--- a/src/pages/DMPage/components/DMList/DMList.tsx
+++ b/src/pages/DMPage/components/DMList/DMList.tsx
@@ -3,6 +3,7 @@ import { Divider } from "@/components";
 import DMItem from "@/pages/DMPage/components/DMItem/DMItem";
 import type { DmListProps } from "@/pages/DMPage/types/dmTypes";
 import { createDMClient } from "@/sockets/dmSocketClient";
+import { useUserId } from "@/stores/useUserId";
 import { theme } from "@/styles/theme/theme";
 import * as s from "@pages/DMPage/components/DMList/DMList.styles";
 import { useEffect, useState } from "react";
@@ -10,7 +11,7 @@ import { useEffect, useState } from "react";
 const DMList = ({ dmList, setRoomId, setUserId }: DmListProps) => {
   const [latestDmList, setLatestDmList] = useState(dmList);
 
-  const userId = 19; // 내 userId - 추후 전역상태로 관리
+  const userId = useUserId();
 
   const handleItemClick = ({ roomId, userId }: { roomId: number; userId: number }) => {
     setRoomId(roomId);
@@ -21,6 +22,7 @@ const DMList = ({ dmList, setRoomId, setUserId }: DmListProps) => {
     setLatestDmList(dmList);
   }, [dmList]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const client = createDMClient(userId, (msg) => {
       setLatestDmList((list) => {

--- a/src/pages/GlobalChatPage/components/GlobalChatRoom/GlobalChatRoom.tsx
+++ b/src/pages/GlobalChatPage/components/GlobalChatRoom/GlobalChatRoom.tsx
@@ -10,6 +10,7 @@ import { useUpdateChatLogs } from "@/pages/GlobalChatPage/hooks/useUpdateChatLog
 import type { ChatTypes } from "@/pages/GlobalChatPage/types/globalChatTypes";
 import { globalChatFormatTime } from "@/pages/GlobalChatPage/utils/globalChatFormatTime";
 import { CHAT_NOTICE_DEFAULT } from "@/pages/HomePage/constants/noticeDummy";
+import { useUserId } from "@/stores/useUserId";
 import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import * as s from "./GlobalChatRoom.styles";
@@ -22,8 +23,9 @@ const GlobalChatRoom = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const serverId = Number(pathname.split("/")[1]);
+
   const roomId = serverId;
-  const myId = Number(localStorage.getItem("userId"));
+  const myId = useUserId();
 
   const stompClient = useGlobalChatStompClient(roomId, setGlobalChatLogs);
   const scrollRef = useScrollToBottom();

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -4,9 +4,11 @@ import CareerList from "@/pages/MyPage/components/CareerList/CareerList";
 import ProfileBox from "@/pages/MyPage/components/ProfileBox/ProfileBox";
 import RecommendedProfiles from "@/pages/MyPage/components/RecommendedProfiles/RecommendedProfiles";
 import { useFetchUserDetail } from "@/pages/MyPage/hooks/useFetchUserDetail";
+import { useUserId } from "@/stores/useUserId";
 
 const MyPage = () => {
-  const userId = localStorage.getItem("userId");
+  const userId = useUserId();
+
   const { data } = useFetchUserDetail(Number(userId));
 
   if (!userId) {

--- a/src/pages/OnboardingPage/components/KakaoLogin/KakaoLogin.tsx
+++ b/src/pages/OnboardingPage/components/KakaoLogin/KakaoLogin.tsx
@@ -1,5 +1,6 @@
 import { useKakaoLogin } from "@/pages/OnboardingPage/hooks/useKakaoLogin";
 import { useRedirectToServer } from "@/pages/OnboardingPage/hooks/useRedirectToServer";
+import { useUserIdAction } from "@/stores/useUserId";
 import { useEffect } from "react";
 
 const KakaoLogin = () => {
@@ -7,17 +8,20 @@ const KakaoLogin = () => {
 
   const { data, isSuccess } = useKakaoLogin(code);
 
+  const { setUserId } = useUserIdAction();
+
   const handleRedirect = useRedirectToServer();
 
   useEffect(() => {
     if (isSuccess && data) {
       localStorage.setItem("accessToken", data.result.accessToken);
       localStorage.setItem("refreshToken", data.result.refreshToken);
-      localStorage.setItem("userId", data.result.userId.toString());
+
+      setUserId(data.result.userId);
 
       handleRedirect();
     }
-  }, [data, isSuccess, handleRedirect]);
+  }, [data, isSuccess, handleRedirect, setUserId]);
 
   return <div>로딩 중</div>;
 };

--- a/src/pages/OnboardingPage/components/KakaoLogin/KakaoLogin.tsx
+++ b/src/pages/OnboardingPage/components/KakaoLogin/KakaoLogin.tsx
@@ -1,14 +1,14 @@
 import { useKakaoLogin } from "@/pages/OnboardingPage/hooks/useKakaoLogin";
 import { useRedirectToServer } from "@/pages/OnboardingPage/hooks/useRedirectToServer";
-import { useUserIdAction } from "@/stores/useUserId";
+import { useUserId, useUserIdAction } from "@/stores/useUserId";
 import { useEffect } from "react";
 
 const KakaoLogin = () => {
   const code = new URL(window.location.href).searchParams.get("code") || "";
 
   const { data, isSuccess } = useKakaoLogin(code);
-
   const { setUserId } = useUserIdAction();
+  const userId = useUserId();
 
   const handleRedirect = useRedirectToServer();
 
@@ -17,7 +17,9 @@ const KakaoLogin = () => {
       localStorage.setItem("accessToken", data.result.accessToken);
       localStorage.setItem("refreshToken", data.result.refreshToken);
 
-      setUserId(data.result.userId);
+      if (data.result.userId) {
+        setUserId(data.result.userId);
+      }
 
       handleRedirect();
     }

--- a/src/pages/OnboardingPage/components/NaverLogin/NaverLogin.tsx
+++ b/src/pages/OnboardingPage/components/NaverLogin/NaverLogin.tsx
@@ -1,6 +1,6 @@
 import { useNaverLogin } from "@/pages/OnboardingPage/hooks/useNaverLogin";
 import { useRedirectToServer } from "@/pages/OnboardingPage/hooks/useRedirectToServer";
-import { useUserId, useUserIdAction } from "@/stores/useUserId";
+import { useUserIdAction } from "@/stores/useUserId";
 import { useEffect } from "react";
 
 const NaverLogin = () => {
@@ -9,7 +9,6 @@ const NaverLogin = () => {
   const { data, isSuccess } = useNaverLogin(code);
 
   const { setUserId } = useUserIdAction();
-  const userId = useUserId();
 
   const handleRedirect = useRedirectToServer();
 
@@ -18,13 +17,13 @@ const NaverLogin = () => {
       localStorage.setItem("accessToken", data.result.accessToken);
       localStorage.setItem("refreshToken", data.result.refreshToken);
 
-      setUserId(data.result.userId);
-
-      console.log(userId);
+      if (data.result.userId) {
+        setUserId(data.result.userId);
+      }
 
       handleRedirect();
     }
-  }, [data, isSuccess, handleRedirect, setUserId, userId]);
+  }, [data, isSuccess, handleRedirect, setUserId]);
 
   return <div>로딩 중</div>;
 };

--- a/src/pages/OnboardingPage/components/NaverLogin/NaverLogin.tsx
+++ b/src/pages/OnboardingPage/components/NaverLogin/NaverLogin.tsx
@@ -1,11 +1,15 @@
 import { useNaverLogin } from "@/pages/OnboardingPage/hooks/useNaverLogin";
 import { useRedirectToServer } from "@/pages/OnboardingPage/hooks/useRedirectToServer";
+import { useUserId, useUserIdAction } from "@/stores/useUserId";
 import { useEffect } from "react";
 
 const NaverLogin = () => {
   const code = new URL(window.location.href).searchParams.get("code") || "";
 
   const { data, isSuccess } = useNaverLogin(code);
+
+  const { setUserId } = useUserIdAction();
+  const userId = useUserId();
 
   const handleRedirect = useRedirectToServer();
 
@@ -14,11 +18,13 @@ const NaverLogin = () => {
       localStorage.setItem("accessToken", data.result.accessToken);
       localStorage.setItem("refreshToken", data.result.refreshToken);
 
-      localStorage.setItem("userId", data.result.userId.toString());
+      setUserId(data.result.userId);
+
+      console.log(userId);
 
       handleRedirect();
     }
-  }, [data, isSuccess, handleRedirect]);
+  }, [data, isSuccess, handleRedirect, setUserId, userId]);
 
   return <div>로딩 중</div>;
 };

--- a/src/pages/UserSettingPage/components/ProfileEdit/ProfileEdit.tsx
+++ b/src/pages/UserSettingPage/components/ProfileEdit/ProfileEdit.tsx
@@ -11,6 +11,7 @@ import { MAX_LENGTH } from "@/pages/UserSettingPage/constants/maxLength";
 import { useEditProfileForm } from "@/pages/UserSettingPage/hooks/useEditProfileForm";
 import { usePostUserProfile } from "@/pages/UserSettingPage/hooks/usePostUserProfile";
 import { useCloseModal, useOpenModal } from "@/stores/useModal";
+import { useUserId } from "@/stores/useUserId";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -23,7 +24,7 @@ const ProfileEdit = () => {
   const closeModal = useCloseModal();
   const openModal = useOpenModal();
 
-  const userId = localStorage.getItem("userId");
+  const userId = useUserId();
   const { data: userData } = useFetchUserDetail(Number(userId));
   const { form, handleInfoChange } = useEditProfileForm(userData);
 

--- a/src/pages/UserSettingPage/hooks/usePostExperience.ts
+++ b/src/pages/UserSettingPage/hooks/usePostExperience.ts
@@ -1,9 +1,10 @@
 import { postExperience } from "@/pages/UserSettingPage/apis/postExperience";
 import type { ExperienceTypes } from "@/pages/UserSettingPage/types/career";
+import { useUserId } from "@/stores/useUserId";
 import { useMutation } from "@tanstack/react-query";
 
 export const usePostExperience = () => {
-  const userId = localStorage.getItem("userId");
+  const userId = useUserId();
 
   return useMutation({
     mutationFn: (data: ExperienceTypes) => postExperience(Number(userId), data),

--- a/src/pages/UserSettingPage/hooks/usePostUserProfile.ts
+++ b/src/pages/UserSettingPage/hooks/usePostUserProfile.ts
@@ -1,9 +1,11 @@
 import { postUserProfile } from "@/pages/UserSettingPage/apis/postUserProfile";
 import type { UserProfileTypes } from "@/pages/UserSettingPage/types/profile";
+import { useUserId } from "@/stores/useUserId";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export const usePostUserProfile = () => {
-  const userId = localStorage.getItem("userId");
+  const userId = useUserId();
+
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/src/stores/useUserId.ts
+++ b/src/stores/useUserId.ts
@@ -1,19 +1,19 @@
 import { create } from "zustand";
 
 type UserStore = {
-  userId: number | null;
+  userId: number;
   actions: {
     setUserId: (id: number | null) => void;
   };
 };
 
 const useUserStore = create<UserStore>((set) => ({
-  userId: null,
+  userId: Number(localStorage.getItem("userId")),
 
   actions: {
     setUserId: (userId: number | null) =>
       set({
-        userId,
+        userId: userId ?? 0,
       }),
   },
 }));

--- a/src/stores/useUserId.ts
+++ b/src/stores/useUserId.ts
@@ -1,19 +1,19 @@
 import { create } from "zustand";
 
 type UserStore = {
-  userId: number;
+  userId: number | null;
   actions: {
     setUserId: (id: number | null) => void;
   };
 };
 
 const useUserStore = create<UserStore>((set) => ({
-  userId: Number(localStorage.getItem("userId")),
+  userId: null,
 
   actions: {
     setUserId: (userId: number | null) =>
       set({
-        userId: userId ?? 0,
+        userId,
       }),
   },
 }));

--- a/src/stores/useUserId.ts
+++ b/src/stores/useUserId.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+
+type UserStore = {
+  userId: number;
+  actions: {
+    setUserId: (id: number | null) => void;
+  };
+};
+
+const useUserStore = create<UserStore>((set) => ({
+  userId: Number(localStorage.getItem("userId")),
+
+  actions: {
+    setUserId: (userId: number | null) =>
+      set({
+        userId: userId ?? 0,
+      }),
+  },
+}));
+
+export const useUserId = () => useUserStore((state) => state.userId);
+export const useUserIdAction = () => useUserStore((state) => state.actions);


### PR DESCRIPTION
## 🎯 관련 이슈

close #117

<br />

## 🚀 작업 내용

- userId 전역상태로 관리


<br />



## 🔎 발견된 장애가 있었나요?

- 새로고침을 하면 기존에 저장된 userId가 날라가요 ...
- 홈 화면이든 다른 api에서 userId를 받아와서 그걸로 관리해야할 것 같습니다

<br />

 

## 💡 어떻게 해결했나요?

- 로컬스토리지 값에서 가져오는 `useInitializeUserId`를 구현했고, 로그인이 되자마자 해당 커스텀 훅을 호출하여 userId를 새로운 값으로 초기화 해준 뒤, 다른 컴포넌트에서 가져올 때는 전역에서 가져오도록 구현했습니다.
- 현재 로그인이 success 되는대로 로컬스토리지의 userId는 지워주는 상태입니다!

다만 생각을 좀 해봐야할게 애초에 userId를 로컬스토리지에 잠깐 저장하는 걸로(현재 코드) 구현할지, 아니면 로그인 api의 값을 가져와서 저장해주는 형태로 할지..가 조금 고민입니다 후자가 더 좋을 것 같긴 한데 의견 부탁드려용

<br />




<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
