### PR TITLE
#123 [FEAT] 경력 수정 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ dist-ssr
 !.yarn/versions
 
 .env
+
+tsconfig.node.tsbuildinfo
+vite.config.js

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -9,7 +9,7 @@ export const PATH = {
   MYPAGE: "/mypage",
   PROFILE_EDIT: "/mypage/setting-profile",
   CAREER_SETTING: "/mypage/setting-career",
-  CAREER_EDIT: "/mypage/setting-edit-career",
+  CAREER_EDIT: "/mypage/setting-edit-career/:experienceId",
   CAREER_ADD: "/mypage/setting-add-career",
 
   HOME: "/:serverId/home",

--- a/src/pages/MyPage/components/CareerBox/CareerBox.tsx
+++ b/src/pages/MyPage/components/CareerBox/CareerBox.tsx
@@ -11,22 +11,24 @@ interface CareerBoxProps {
   contentList?: string[];
 }
 
-const CareerBox = ({ id, title, startDate, endDate, contentList }: CareerBoxProps) => {
+const CareerBox = ({ ...career }: CareerBoxProps) => {
   return (
-    <li key={id}>
+    <li key={career.id}>
       <section css={s.wrapperStyle}>
         <div css={s.layoutStyle}>
           <div css={s.titleLayoutStyle}>
             <RotateLogoIcon width={15} height={13} css={{ flexShrink: "0" }} />
-            <h1 css={s.titleStyle}>{title}&nbsp;&nbsp;&nbsp;·</h1>
+            <h1 css={s.titleStyle}>{career.title}&nbsp;&nbsp;&nbsp;·</h1>
           </div>
           <div css={s.periodStyle}>
-            {endDate ? `${formatDateRange(startDate, endDate)}` : formatDateRange(startDate, startDate)}
+            {career.endDate
+              ? `${formatDateRange(career.startDate, career.endDate)}`
+              : formatDateRange(career.startDate, career.startDate)}
           </div>
         </div>
         <Divider />
         <ul css={s.listLayoutStyle}>
-          {contentList?.map((item, index) => (
+          {career.contentList?.map((item, index) => (
             <li key={`${index}-${item}`} css={s.itemStyle}>
               ·&nbsp;&nbsp;{item}
             </li>

--- a/src/pages/UserSettingPage/apis/updateExperience.ts
+++ b/src/pages/UserSettingPage/apis/updateExperience.ts
@@ -1,8 +1,8 @@
-import { tokenInstance } from "@/apis/instance";
+import { formDataInstance } from "@/apis/instance";
 import type { ExperienceTypes } from "@/pages/UserSettingPage/types/career";
 
 export const updateExperience = async (userId: number, experienceId: number, data: ExperienceTypes) => {
-  const response = await tokenInstance
+  const response = await formDataInstance
     .post(`api/v1/users/${userId}/experiences/${experienceId}`, { json: data })
     .json();
 

--- a/src/pages/UserSettingPage/apis/updateExperience.ts
+++ b/src/pages/UserSettingPage/apis/updateExperience.ts
@@ -1,0 +1,10 @@
+import { tokenInstance } from "@/apis/instance";
+import type { ExperienceTypes } from "@/pages/UserSettingPage/types/career";
+
+export const updateExperience = async (userId: number, experienceId: number, data: ExperienceTypes) => {
+  const response = await tokenInstance
+    .post(`api/v1/users/${userId}/experiences/${experienceId}`, { json: data })
+    .json();
+
+  return response;
+};

--- a/src/pages/UserSettingPage/components/CareerBoxChip/CareerBoxChip.tsx
+++ b/src/pages/UserSettingPage/components/CareerBoxChip/CareerBoxChip.tsx
@@ -5,13 +5,19 @@ import * as s from "@/pages/UserSettingPage/components/CareerBoxChip/CareerBoxCh
 import { useNavigate } from "react-router-dom";
 
 interface CareerBoxProps {
+  id: number;
   title: string;
-  period: string;
-  descriptions?: string[];
+  startDate: number[];
+  endDate: number[];
+  contentList?: string[];
 }
 
-const CareerBoxChip = ({ title, period, descriptions }: CareerBoxProps) => {
+const CareerBoxChip = ({ id, ...career }: CareerBoxProps) => {
   const navigate = useNavigate();
+
+  const startDate = career.startDate.slice(0, 3).join("-");
+  const endDate = career.endDate.slice(0, 3).join("-");
+  const period = `${startDate} ~ ${endDate}`;
 
   return (
     <li>
@@ -22,24 +28,20 @@ const CareerBoxChip = ({ title, period, descriptions }: CareerBoxProps) => {
         <header css={s.layoutStyle}>
           <div css={s.titleBoxStyle}>
             <div css={s.titleLayoutStyle}>
-              <RotateLogoIcon
-                width={15}
-                height={13}
-                css={{ flexShrink: "0" }}
-              />
-              <h1 css={s.titleStyle}>{title}&nbsp;&nbsp;&nbsp;·</h1>
+              <RotateLogoIcon width={15} height={13} css={{ flexShrink: "0" }} />
+              <h1 css={s.titleStyle}>{career.title}&nbsp;&nbsp;&nbsp;·</h1>
             </div>
             <p css={s.periodStyle}>{period}</p>
           </div>
           <EditBlueIcon
             width={19}
             css={s.editIconStyle}
-            onClick={() => navigate("/mypage/setting-edit-career")}
+            onClick={() => navigate(`/mypage/setting-edit-career/${id}`)}
           />
         </header>
         <Divider />
         <ul css={s.listLayoutStyle}>
-          {descriptions?.map((item, index) => (
+          {career?.contentList?.map((item, index) => (
             <li key={`${index}-${item}`} css={s.itemStyle}>
               ·&nbsp;&nbsp;{item}
             </li>
@@ -49,5 +51,4 @@ const CareerBoxChip = ({ title, period, descriptions }: CareerBoxProps) => {
     </li>
   );
 };
-
 export default CareerBoxChip;

--- a/src/pages/UserSettingPage/components/CareerEdit/CareerEdit.styles.ts
+++ b/src/pages/UserSettingPage/components/CareerEdit/CareerEdit.styles.ts
@@ -38,7 +38,6 @@ export const fieldStyle = css`
 
 export const labelStyle = css`
   display: flex;
-  align-items: center;
 
   color: ${theme.color.gray2};
   ${theme.font.body2};
@@ -68,13 +67,17 @@ export const datePickerStyle = css`
 }
 `;
 
-export const checkboxStyle = css`
+export const checkboxLayoutStyle = css`
   display: flex;
 
   margin-right: 12rem;
 
   align-items: center;
   gap: 1.3rem;
+
+  & > div {
+  margin: 3rem 0 0 2rem;
+  }
 `;
 
 export const iconStyle = css`

--- a/src/pages/UserSettingPage/components/CareerEdit/CareerEdit.tsx
+++ b/src/pages/UserSettingPage/components/CareerEdit/CareerEdit.tsx
@@ -8,8 +8,8 @@ import * as s from "@/pages/UserSettingPage/components/CareerEdit/CareerEdit.sty
 import { MAX_LENGTH } from "@/pages/UserSettingPage/constants/maxLength";
 import { useEditCareerForm } from "@/pages/UserSettingPage/hooks/useEditCareerForm";
 import { useUpdateExperience } from "@/pages/UserSettingPage/hooks/useUpdateExperience";
+import { formatDate, parseDateStringToArray } from "@/pages/UserSettingPage/utils/date";
 
-import { formatDateArray } from "@/utils/dateTime";
 import type { FormEvent } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
@@ -30,6 +30,7 @@ const CareerEdit = () => {
     handleDetailChange,
     handleAddDetailInput,
     handleDeleteDetailInput,
+    handleDateInput,
     setIsCurrentJob,
   } = useEditCareerForm(selectedExperience);
 
@@ -40,8 +41,8 @@ const CareerEdit = () => {
       experienceId: Number(experienceId),
       data: {
         title: careerData.title,
-        startDate: careerData.startDate,
-        endDate: careerData.endDate,
+        startDate: parseDateStringToArray(careerData.startDate) || [],
+        endDate: careerData.endDate ? parseDateStringToArray(careerData.endDate) || [] : null,
         contentList: careerData.contentList,
       },
     });
@@ -77,13 +78,19 @@ const CareerEdit = () => {
             기간
           </label>
           <div css={s.datePickerStyle}>
-            <Input variant="secondary" value={formatDateArray(careerData.startDate)} onChange={() => {}} />
+            <Input
+              variant="secondary"
+              value={careerData.startDate ? formatDate(careerData.startDate) : ""}
+              onChange={(e) => handleDateInput(e, "startDate")}
+              placeholder="YYYY.MM.DD"
+            />
             <p css={{ marginRight: "1.3rem" }}>부터</p>
             <Input
               variant="secondary"
-              value={careerData.endDate ? formatDateArray(careerData.endDate) : ""}
-              onChange={() => {}}
+              value={careerData.endDate ? formatDate(careerData.endDate) : ""}
+              onChange={(e) => handleDateInput(e, "endDate")}
               disabled={!careerData.endDate}
+              placeholder="YYYY.MM.DD"
             />
             <p>까지</p>
             <Divider direction="horizontal" />

--- a/src/pages/UserSettingPage/components/CareerEdit/CareerEdit.tsx
+++ b/src/pages/UserSettingPage/components/CareerEdit/CareerEdit.tsx
@@ -1,17 +1,27 @@
 import PlusBlueIcon from "@/assets/svg/PlusBlueIcon";
 import { Button, CheckBox, Divider, Input } from "@/components";
 import { PATH } from "@/constants/path";
+import { useFetchUserDetail } from "@/pages/MyPage/hooks/useFetchUserDetail";
 import CareerDetailChip from "@/pages/UserSettingPage/components/CareerDetailChip/CareerDetailChip";
 import * as s from "@/pages/UserSettingPage/components/CareerEdit/CareerEdit.styles";
-import { careerDummyData } from "@/pages/UserSettingPage/constants/dummy";
 
 import { MAX_LENGTH } from "@/pages/UserSettingPage/constants/maxLength";
 import { useEditCareerForm } from "@/pages/UserSettingPage/hooks/useEditCareerForm";
+import { useUpdateExperience } from "@/pages/UserSettingPage/hooks/useUpdateExperience";
+
 import { formatDateArray } from "@/utils/dateTime";
-import { useNavigate } from "react-router-dom";
+import type { FormEvent } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 
 const CareerEdit = () => {
   const navigate = useNavigate();
+  const { experienceId } = useParams();
+  const userId = localStorage.getItem("userId");
+
+  const { data } = useFetchUserDetail(Number(userId));
+  const { mutate: updateCareer } = useUpdateExperience();
+
+  const selectedExperience = data.experience.experienceList.find((exp) => exp.id === Number(experienceId));
 
   const {
     careerData,
@@ -21,7 +31,23 @@ const CareerEdit = () => {
     handleAddDetailInput,
     handleDeleteDetailInput,
     setIsCurrentJob,
-  } = useEditCareerForm(careerDummyData);
+  } = useEditCareerForm(selectedExperience);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+
+    updateCareer({
+      experienceId: Number(experienceId),
+      data: {
+        title: careerData.title,
+        startDate: careerData.startDate,
+        endDate: careerData.endDate,
+        contentList: careerData.contentList,
+      },
+    });
+
+    navigate(PATH.CAREER_SETTING);
+  };
 
   return (
     <div css={s.pageStyle}>
@@ -38,7 +64,6 @@ const CareerEdit = () => {
             value={careerData.title}
             onChange={(e) => {
               const { value } = e.target;
-
               if (value.length > MAX_LENGTH.CAREER_DETAIL_TITLE) {
                 setCareerData((prev) => ({ ...prev, title: value.slice(0, MAX_LENGTH.CAREER_DETAIL_TITLE) }));
               } else {
@@ -47,7 +72,6 @@ const CareerEdit = () => {
             }}
           />
         </div>
-
         <div css={s.fieldStyle}>
           <label htmlFor="period" css={s.labelStyle}>
             기간
@@ -76,7 +100,6 @@ const CareerEdit = () => {
             </div>
           </div>
         </div>
-
         <div css={s.fieldStyle}>
           <div css={{ display: "flex", gap: "0.73rem" }}>
             <label htmlFor="detail" css={s.labelStyle}>
@@ -88,7 +111,6 @@ const CareerEdit = () => {
               <p css={s.labelStyle}>/{MAX_LENGTH.DETAIL_COUNT}</p>
             </span>
           </div>
-
           {careerData.contentList.map((detail, index) =>
             index === 0 ? (
               <Input
@@ -107,7 +129,6 @@ const CareerEdit = () => {
               />
             ),
           )}
-
           {careerData.contentList.length < MAX_LENGTH.DETAIL_COUNT && (
             <button type="button" css={s.iconStyle} onClick={handleAddDetailInput}>
               <PlusBlueIcon width={16} height={16} />
@@ -119,12 +140,11 @@ const CareerEdit = () => {
         <Button size="medium" variant="tertiary" onClick={() => navigate(PATH.CAREER_SETTING)}>
           뒤로 가기
         </Button>
-        <Button size="medium" onClick={() => navigate(PATH.CAREER_SETTING)}>
+        <Button size="medium" onClick={handleSubmit}>
           추가 하기
         </Button>
       </div>
     </div>
   );
 };
-
 export default CareerEdit;

--- a/src/pages/UserSettingPage/components/CareerEdit/CareerEdit.tsx
+++ b/src/pages/UserSettingPage/components/CareerEdit/CareerEdit.tsx
@@ -31,7 +31,7 @@ const CareerEdit = () => {
     handleAddDetailInput,
     handleDeleteDetailInput,
     handleDateInput,
-    setIsCurrentJob,
+    handleCheckBoxChange,
   } = useEditCareerForm(selectedExperience);
 
   const handleSubmit = (e: FormEvent) => {
@@ -41,8 +41,8 @@ const CareerEdit = () => {
       experienceId: Number(experienceId),
       data: {
         title: careerData.title,
-        startDate: parseDateStringToArray(careerData.startDate) || [],
-        endDate: careerData.endDate ? parseDateStringToArray(careerData.endDate) || [] : null,
+        startDate: parseDateStringToArray(formatDate(careerData.startDate)) || [],
+        endDate: careerData.endDate ? parseDateStringToArray(formatDate(careerData.endDate)) : null,
         contentList: careerData.contentList,
       },
     });
@@ -94,15 +94,15 @@ const CareerEdit = () => {
             />
             <p>까지</p>
             <Divider direction="horizontal" />
-            <div css={s.checkboxStyle}>
+            <div css={s.checkboxLayoutStyle}>
               <label htmlFor="current-job" css={s.labelStyle}>
                 현직
               </label>
               <CheckBox
                 id="current-job"
                 variant="round"
-                isChecked={careerData.endDate === null}
-                onChange={() => setIsCurrentJob(careerData.endDate !== null)}
+                isChecked={careerData.endDate === ""}
+                onChange={handleCheckBoxChange}
               />
             </div>
           </div>

--- a/src/pages/UserSettingPage/components/CareerSettingList/CareerSettingList.tsx
+++ b/src/pages/UserSettingPage/components/CareerSettingList/CareerSettingList.tsx
@@ -1,13 +1,18 @@
 import { PlusIcon } from "@/assets/svg";
 import { Button } from "@/components";
 import { PATH } from "@/constants/path";
-import { careerData } from "@/pages/MyPage/constants/dummy";
+import { useFetchUserDetail } from "@/pages/MyPage/hooks/useFetchUserDetail";
 import CareerBoxChip from "@/pages/UserSettingPage/components/CareerBoxChip/CareerBoxChip";
 import * as s from "@/pages/UserSettingPage/components/CareerSettingList/CareerSettingList.styles";
 import { useNavigate } from "react-router-dom";
 
 const CareerSettingList = () => {
   const navigate = useNavigate();
+
+  const userId = localStorage.getItem("userId");
+  const { data } = useFetchUserDetail(Number(userId));
+
+  const experienceData = data.experience.experienceList;
 
   return (
     <div css={s.pageStyle}>
@@ -24,7 +29,7 @@ const CareerSettingList = () => {
         </button>
       </div>
       <ul css={s.listStyle}>
-        {careerData.map((career, index) => (
+        {experienceData.map((career, index) => (
           <CareerBoxChip key={`${career.title}-${index}`} {...career} css={{ position: "relative" }} />
         ))}
       </ul>

--- a/src/pages/UserSettingPage/hooks/useEditCareerForm.ts
+++ b/src/pages/UserSettingPage/hooks/useEditCareerForm.ts
@@ -1,13 +1,13 @@
 import type { CareerResponseTypes, ExperienceTypes } from "@/pages/UserSettingPage/types/career";
-import { formatDate } from "@/pages/UserSettingPage/utils/date";
+import { formatDate, formatDateArrayToString } from "@/pages/UserSettingPage/utils/date";
 import { useCallback, useState } from "react";
 
 export const useEditCareerForm = (data?: ExperienceTypes) => {
   const [careerData, setCareerData] = useState<CareerResponseTypes>({
     title: data?.title ?? "",
     contentList: data?.contentList ?? [""],
-    startDate: data?.startDate ? formatDate(data.startDate.join("")) : "",
-    endDate: data?.endDate ? formatDate(data.endDate.join("")) : "",
+    startDate: data?.startDate ? formatDateArrayToString(data.startDate) : "",
+    endDate: data?.endDate ? formatDateArrayToString(data.endDate) : "",
   });
 
   const handleInputChange = useCallback((key: keyof CareerResponseTypes, value: string) => {
@@ -35,22 +35,15 @@ export const useEditCareerForm = (data?: ExperienceTypes) => {
     }));
   };
 
-  const setIsCurrentJob = (isCurrent: boolean) => {
+  const handleCheckBoxChange = () => {
     setCareerData((prev) => ({
       ...prev,
-      endDate: isCurrent ? "" : prev.endDate,
+      endDate: prev.endDate ? "" : formatDate(new Date().toISOString().slice(0, 10).replace(/-/g, ".")),
     }));
   };
 
   const handleDateInput = useCallback((e: React.ChangeEvent<HTMLInputElement>, dateType: "startDate" | "endDate") => {
-    const value = e.target.value.replace(/\D/g, ""); // 숫자만 남기기
-    if (value === "") {
-      setCareerData((prev) => ({ ...prev, [dateType]: "" }));
-      return;
-    }
-
-    const formattedValue = formatDate(value);
-    setCareerData((prev) => ({ ...prev, [dateType]: formattedValue }));
+    setCareerData((prev) => ({ ...prev, [dateType]: e.target.value }));
   }, []);
 
   return {
@@ -60,7 +53,7 @@ export const useEditCareerForm = (data?: ExperienceTypes) => {
     handleDetailChange,
     handleAddDetailInput,
     handleDeleteDetailInput,
-    setIsCurrentJob,
+    handleCheckBoxChange,
     handleDateInput,
   };
 };

--- a/src/pages/UserSettingPage/hooks/useEditCareerForm.ts
+++ b/src/pages/UserSettingPage/hooks/useEditCareerForm.ts
@@ -1,47 +1,31 @@
-import { MAX_LENGTH } from "@/pages/UserSettingPage/constants/maxLength";
-import type { CareerContentTypes } from "@/pages/UserSettingPage/types/career";
+import type { CareerResponseTypes, ExperienceTypes } from "@/pages/UserSettingPage/types/career";
+import { formatDate } from "@/pages/UserSettingPage/utils/date";
 import { useCallback, useState } from "react";
 
-export const useEditCareerForm = (data?: CareerContentTypes) => {
-  const [careerData, setCareerData] = useState<CareerContentTypes>({
+export const useEditCareerForm = (data?: ExperienceTypes) => {
+  const [careerData, setCareerData] = useState<CareerResponseTypes>({
     title: data?.title ?? "",
     contentList: data?.contentList ?? [""],
-    startDate: data?.startDate ?? [0, 0, 0, 0, 0, 0, 0],
-    endDate: data?.endDate ?? null,
+    startDate: data?.startDate ? formatDate(data.startDate.join("")) : "",
+    endDate: data?.endDate ? formatDate(data.endDate.join("")) : "",
   });
 
-  const handleInputChange = useCallback((key: keyof CareerContentTypes, value: string | number[]) => {
-    const maxLength = MAX_LENGTH[key as keyof typeof MAX_LENGTH];
-
-    let slicedValue = value;
-
-    if (typeof value === "string" && value.length > maxLength) {
-      slicedValue = value.slice(0, maxLength - 1);
-    }
-
-    setCareerData((prev) => ({ ...prev, [key]: slicedValue }));
+  const handleInputChange = useCallback((key: keyof CareerResponseTypes, value: string) => {
+    setCareerData((prev) => ({ ...prev, [key]: value }));
   }, []);
 
   const handleDetailChange = useCallback((index: number, value: string) => {
-    let slicedValue = value;
-
-    if (value.length > MAX_LENGTH.DETAIL) {
-      slicedValue = value.slice(0, MAX_LENGTH.DETAIL - 1);
-    }
-
     setCareerData((prev) => ({
       ...prev,
-      contentList: prev.contentList.map((detail, i) => (i === index ? slicedValue : detail)),
+      contentList: prev.contentList.map((detail, i) => (i === index ? value : detail)),
     }));
   }, []);
 
   const handleAddDetailInput = () => {
-    if (careerData.contentList.length < MAX_LENGTH.DETAIL_COUNT) {
-      setCareerData((prev) => ({
-        ...prev,
-        contentList: [...prev.contentList, ""],
-      }));
-    }
+    setCareerData((prev) => ({
+      ...prev,
+      contentList: [...prev.contentList, ""],
+    }));
   };
 
   const handleDeleteDetailInput = (index: number) => {
@@ -54,9 +38,20 @@ export const useEditCareerForm = (data?: CareerContentTypes) => {
   const setIsCurrentJob = (isCurrent: boolean) => {
     setCareerData((prev) => ({
       ...prev,
-      endDate: isCurrent ? null : [0, 0, 0, 0, 0, 0, 0],
+      endDate: isCurrent ? "" : prev.endDate,
     }));
   };
+
+  const handleDateInput = useCallback((e: React.ChangeEvent<HTMLInputElement>, dateType: "startDate" | "endDate") => {
+    const value = e.target.value.replace(/\D/g, ""); // 숫자만 남기기
+    if (value === "") {
+      setCareerData((prev) => ({ ...prev, [dateType]: "" }));
+      return;
+    }
+
+    const formattedValue = formatDate(value);
+    setCareerData((prev) => ({ ...prev, [dateType]: formattedValue }));
+  }, []);
 
   return {
     careerData,
@@ -66,5 +61,6 @@ export const useEditCareerForm = (data?: CareerContentTypes) => {
     handleAddDetailInput,
     handleDeleteDetailInput,
     setIsCurrentJob,
+    handleDateInput,
   };
 };

--- a/src/pages/UserSettingPage/hooks/useUpdateExperience.ts
+++ b/src/pages/UserSettingPage/hooks/useUpdateExperience.ts
@@ -1,0 +1,18 @@
+import { updateExperience } from "@/pages/UserSettingPage/apis/updateExperience";
+import type { ExperienceTypes } from "@/pages/UserSettingPage/types/career";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export const useUpdateExperience = () => {
+  const userId = localStorage.getItem("userId");
+
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ experienceId, data }: { experienceId: number; data: ExperienceTypes }) =>
+      updateExperience(Number(userId), experienceId, data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fetchUserDetail"] });
+    },
+  });
+};

--- a/src/pages/UserSettingPage/types/career.ts
+++ b/src/pages/UserSettingPage/types/career.ts
@@ -1,8 +1,15 @@
 export interface CareerContentTypes {
   title: string;
   contentList: string[];
-  startDate: number[];
-  endDate: number[] | null;
+  startDate: string;
+  endDate: string | null;
+}
+
+export interface CareerResponseTypes {
+  title: string;
+  contentList: string[];
+  startDate: string;
+  endDate: string | null;
 }
 
 export interface ExperienceTypes {

--- a/src/pages/UserSettingPage/utils/date.ts
+++ b/src/pages/UserSettingPage/utils/date.ts
@@ -1,6 +1,5 @@
 // 숫자 배열을 "YYYY.MM.DD" 문자열로 변환
 export const formatDateArrayToString = (dateArray: number[]) => {
-  if (!dateArray || dateArray.length < 3) return "";
   return `${dateArray[0]}.${String(dateArray[1]).padStart(2, "0")}.${String(dateArray[2]).padStart(2, "0")}`;
 };
 
@@ -15,11 +14,10 @@ export const formatDate = (date: string) => {
   return `${year}.${month}.${day}`;
 };
 
-export const parseDateStringToArray = (dateString: string | number[]) => {
-  if (Array.isArray(dateString)) {
-    return dateString.length >= 3 ? [...dateString, 0, 0, 0, 0] : null;
-  }
+export const parseDateStringToArray = (dateString: string) => {
   if (!/^\d{4}\.\d{2}\.\d{2}$/.test(dateString)) return null;
+
   const parts = dateString.split(".").map(Number);
+
   return [...parts, 0, 0, 0, 0];
 };

--- a/src/pages/UserSettingPage/utils/date.ts
+++ b/src/pages/UserSettingPage/utils/date.ts
@@ -1,0 +1,25 @@
+// 숫자 배열을 "YYYY.MM.DD" 문자열로 변환
+export const formatDateArrayToString = (dateArray: number[]) => {
+  if (!dateArray || dateArray.length < 3) return "";
+  return `${dateArray[0]}.${String(dateArray[1]).padStart(2, "0")}.${String(dateArray[2]).padStart(2, "0")}`;
+};
+
+export const formatDate = (date: string) => {
+  if (!/^\d{8}$/.test(date)) {
+    return date;
+  }
+  const year = date.slice(0, 4);
+  const month = date.slice(4, 6);
+  const day = date.slice(6, 8);
+
+  return `${year}.${month}.${day}`;
+};
+
+export const parseDateStringToArray = (dateString: string | number[]) => {
+  if (Array.isArray(dateString)) {
+    return dateString.length >= 3 ? [...dateString, 0, 0, 0, 0] : null;
+  }
+  if (!/^\d{4}\.\d{2}\.\d{2}$/.test(dateString)) return null;
+  const parts = dateString.split(".").map(Number);
+  return [...parts, 0, 0, 0, 0];
+};

--- a/vite.config.d.ts
+++ b/vite.config.d.ts
@@ -1,0 +1,2 @@
+declare const _default: import("vite").UserConfig;
+export default _default;


### PR DESCRIPTION
## 🎯 관련 이슈

close #123 

<br />

## 🚀 작업 내용

- 경력 수정 api 연결

<br />


## 📸 스크린샷


https://github.com/user-attachments/assets/e80d13cd-2bb9-4bb9-aa2e-bbacb7d37640


<br />



## 🔎 발견된 장애가 있었나요?

- 이전에 말씀드린대로 경력의 date 입력은 연도를 구별해야 할 일이 많을 것 같아서 인풋으로 구현했습니다.
- string으로 입력받은 다음 post시에 number 배열로 변환해서 보냈습니다.

<br />

 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
