### PR TITLE
#129 [FEAT] 해시태그 검색 API 연결

### DIFF
--- a/src/components/NoDataContainer/NoDataContainer.styles.ts
+++ b/src/components/NoDataContainer/NoDataContainer.styles.ts
@@ -16,7 +16,7 @@ export const sectionStyle = (image: string) => css`
 
   row-gap: 3.4rem;
 
-  border-radius: 2.5rem;
+  border-radius: 1rem;
 
   background-color: ${theme.color.dark3};
   background-image: url(${image});

--- a/src/components/SearchLayout/SearchLayout.styles.ts
+++ b/src/components/SearchLayout/SearchLayout.styles.ts
@@ -18,3 +18,9 @@ export const hashTagListStyle = css`
 
   max-height: 3.1rem;
 `;
+
+export const emptyHashtagBoxStyle = css`
+  visibility: hidden;
+  
+  height: 3.1rem;
+`;

--- a/src/components/SearchLayout/SearchLayout.tsx
+++ b/src/components/SearchLayout/SearchLayout.tsx
@@ -51,11 +51,7 @@ const SearchLayout = <T extends QueryParamTypes | HomeQueryParamTypes>({
             );
           })
         ) : (
-          <li css={{ visibility: "hidden" }}>
-            <Button variant="hashtag" size="semiLarge">
-              Placeholder
-            </Button>
-          </li>
+          <div css={s.emptyHashtagBoxStyle} />
         )}
       </ul>
     </div>

--- a/src/components/SearchLayout/SearchLayout.tsx
+++ b/src/components/SearchLayout/SearchLayout.tsx
@@ -1,17 +1,20 @@
 import { RotateLogoIcon } from "@/assets/svg";
 import { Button, Input } from "@/components";
 import { useUpdateSearchParam } from "@/components/SearchLayout/hooks/useUpdateSearchParam";
-import type { QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
+import type { HomeQueryParamTypes, QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
 import type { HashtagTypes } from "@/components/TagChip/types/tagChipTypes";
 import * as s from "./SearchLayout.styles";
-
-interface SearchLayoutProps {
-  queryParam: QueryParamTypes;
-  setQueryParam: (searchParam: QueryParamTypes) => void;
+interface SearchLayoutProps<T extends QueryParamTypes | HomeQueryParamTypes> {
+  queryParam: T;
+  setQueryParam: (searchParam: T) => void;
   hashTagData: HashtagTypes[];
 }
 
-const SearchLayout = ({ queryParam, setQueryParam, hashTagData }: SearchLayoutProps) => {
+const SearchLayout = <T extends QueryParamTypes | HomeQueryParamTypes>({
+  queryParam,
+  setQueryParam,
+  hashTagData,
+}: SearchLayoutProps<T>) => {
   const { updateField, updateTagList } = useUpdateSearchParam(queryParam, setQueryParam);
 
   return (
@@ -20,28 +23,36 @@ const SearchLayout = ({ queryParam, setQueryParam, hashTagData }: SearchLayoutPr
         leftIcon={<RotateLogoIcon width={18} />}
         placeholder="관심있는 키워드를 검색해보세요!"
         value={queryParam.keyword}
-        onChange={(e) => updateField("keyword", e.target.value)}
+        onChange={(e) => updateField("keyword", e.target.value as T["keyword"])}
       />
       <ul css={s.hashTagListStyle}>
-        {hashTagData.map((tag) => {
-          const isSelected = queryParam.tags.includes(tag.content);
-          return (
-            <li key={tag.id}>
-              <Button
-                variant="hashtag"
-                size="semiLarge"
-                onClick={() => updateTagList(tag.content)}
-                css={{
-                  color: isSelected ? "white" : "",
-                  backgroundColor: isSelected ? "#3f4b5d;" : "",
-                  fontWeight: isSelected ? "500;" : "",
-                }}
-              >
-                {tag.content}
-              </Button>
-            </li>
-          );
-        })}
+        {hashTagData.length > 0 ? (
+          hashTagData.map((tag) => {
+            const isSelected = queryParam.tags.includes(tag.content);
+            return (
+              <li key={tag.id}>
+                <Button
+                  variant="hashtag"
+                  size="semiLarge"
+                  onClick={() => updateTagList(tag.content)}
+                  css={{
+                    color: isSelected ? "white" : "",
+                    backgroundColor: isSelected ? "#3f4b5d;" : "",
+                    fontWeight: isSelected ? "500;" : "",
+                  }}
+                >
+                  {tag.content}
+                </Button>
+              </li>
+            );
+          })
+        ) : (
+          <li css={{ visibility: "hidden" }}>
+            <Button variant="hashtag" size="semiLarge">
+              Placeholder
+            </Button>
+          </li>
+        )}
       </ul>
     </div>
   );

--- a/src/components/SearchLayout/SearchLayout.tsx
+++ b/src/components/SearchLayout/SearchLayout.tsx
@@ -17,6 +17,10 @@ const SearchLayout = <T extends QueryParamTypes | HomeQueryParamTypes>({
 }: SearchLayoutProps<T>) => {
   const { updateField, updateTagList } = useUpdateSearchParam(queryParam, setQueryParam);
 
+  const selectedTags = queryParam.tags.map((tag, index) => ({ id: -index - 1, content: tag }));
+  const uniqueHashTagData = hashTagData.filter((tag) => !queryParam.tags.includes(tag.content));
+  const includeSelectedTags = [...selectedTags, ...uniqueHashTagData];
+
   return (
     <div css={s.searchLayoutStyle}>
       <Input
@@ -26,8 +30,8 @@ const SearchLayout = <T extends QueryParamTypes | HomeQueryParamTypes>({
         onChange={(e) => updateField("keyword", e.target.value as T["keyword"])}
       />
       <ul css={s.hashTagListStyle}>
-        {hashTagData.length > 0 ? (
-          hashTagData.map((tag) => {
+        {includeSelectedTags.length > 0 ? (
+          includeSelectedTags.map((tag) => {
             const isSelected = queryParam.tags.includes(tag.content);
             return (
               <li key={tag.id}>

--- a/src/components/SearchLayout/SearchLayout.tsx
+++ b/src/components/SearchLayout/SearchLayout.tsx
@@ -7,7 +7,7 @@ import * as s from "./SearchLayout.styles";
 interface SearchLayoutProps<T extends QueryParamTypes | HomeQueryParamTypes> {
   queryParam: T;
   setQueryParam: (searchParam: T) => void;
-  hashTagData: HashtagTypes[];
+  hashTagData: HashtagTypes[] | [];
 }
 
 const SearchLayout = <T extends QueryParamTypes | HomeQueryParamTypes>({

--- a/src/components/SearchLayout/apis/hashtagSearch.ts
+++ b/src/components/SearchLayout/apis/hashtagSearch.ts
@@ -1,0 +1,31 @@
+import { tokenInstance } from "@/apis/instance";
+import type { HashTagResponse } from "@/components/SearchLayout/types/searchTypes";
+import type { HashtagTypes } from "@/pages/HomePage/types/homeDataTypes";
+
+export interface FetchHashtagSerachProps {
+  serverId: number;
+  keyword?: string;
+  tags?: string[];
+}
+
+export const fetchHashtagSerach = async ({
+  serverId,
+  keyword,
+  tags,
+}: FetchHashtagSerachProps): Promise<HashtagTypes[] | []> => {
+  try {
+    const queryParams = new URLSearchParams();
+
+    if (keyword) queryParams.append("keyword", keyword);
+    if (tags && tags.length > 0) {
+      for (const tag of tags) {
+        queryParams.append("tags", tag);
+      }
+    }
+    const response: HashTagResponse = await tokenInstance.get(`api/v1/servers/${serverId}/tags?${queryParams}`).json();
+    return response.result.hashTagList;
+  } catch (error) {
+    console.error("해시태그 검색 실패:", error);
+    throw error;
+  }
+};

--- a/src/components/SearchLayout/constants/searchInitial.ts
+++ b/src/components/SearchLayout/constants/searchInitial.ts
@@ -1,4 +1,4 @@
-import type { QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
+import type { HomeQueryParamTypes, QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
 
 export const INITIAL_SELECTED_ITEM = { id: null, type: null };
 
@@ -6,6 +6,11 @@ export const INITIAL_QUERY_PARAM: QueryParamTypes = {
   page: 0,
   sort: "",
   scope: "",
+  keyword: "",
+  tags: [],
+};
+
+export const HOME_QUERY_PARAM: HomeQueryParamTypes = {
   keyword: "",
   tags: [],
 };

--- a/src/components/SearchLayout/hooks/useHashtagSearch.ts
+++ b/src/components/SearchLayout/hooks/useHashtagSearch.ts
@@ -1,0 +1,15 @@
+import { type FetchHashtagSerachProps, fetchHashtagSerach } from "@/components/SearchLayout/apis/hashtagSearch";
+import { useQuery } from "@tanstack/react-query";
+
+export const useHashtagSearch = ({ serverId, keyword, tags }: FetchHashtagSerachProps) => {
+  return useQuery({
+    queryKey: ["searchResult", serverId, keyword, tags],
+    queryFn: () =>
+      fetchHashtagSerach({
+        serverId,
+        keyword,
+        tags,
+      }),
+    enabled: !!serverId,
+  });
+};

--- a/src/components/SearchLayout/hooks/useUpdateSearchParam.ts
+++ b/src/components/SearchLayout/hooks/useUpdateSearchParam.ts
@@ -1,7 +1,10 @@
-import type { QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
+import type { HomeQueryParamTypes, QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
 
-export const useUpdateSearchParam = (param: QueryParamTypes, setParam: (param: QueryParamTypes) => void) => {
-  const updateField = (field: keyof QueryParamTypes, value: string | number | string[]) => {
+export const useUpdateSearchParam = <T extends QueryParamTypes | HomeQueryParamTypes>(
+  param: T,
+  setParam: (param: T) => void
+) => {
+  const updateField = (field: keyof T, value: T[keyof T]) => {
     setParam({
       ...param,
       [field]: value,
@@ -9,13 +12,14 @@ export const useUpdateSearchParam = (param: QueryParamTypes, setParam: (param: Q
   };
 
   const updateTagList = (tagContent: string) => {
-    const isTagExist = param.tags.includes(tagContent);
+    if (!param || !Array.isArray(param.tags)) return; 
 
+    const isTagExist = param.tags.includes(tagContent);
     const updatedTagList = isTagExist
       ? param.tags.filter((tagContentInList) => tagContentInList !== tagContent)
       : [...param.tags, tagContent];
 
-    updateField("tags", updatedTagList);
+    updateField("tags", updatedTagList as T[keyof T]);
   };
 
   return { updateField, updateTagList };

--- a/src/components/SearchLayout/types/searchTypes.ts
+++ b/src/components/SearchLayout/types/searchTypes.ts
@@ -1,3 +1,5 @@
+import type { HashtagTypes, PageInfoTypes } from "@/pages/HomePage/types/homeDataTypes";
+
 export interface QueryParamTypes {
   page: number;
   sort: string;
@@ -15,4 +17,14 @@ export interface SearchParamTypes {
   serverId: number;
   type: string;
   queryParam: QueryParamTypes;
+}
+
+export interface HashTagResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    pageInfo: PageInfoTypes;
+    hashTagList: HashtagTypes[];
+  };
 }

--- a/src/components/SearchLayout/types/searchTypes.ts
+++ b/src/components/SearchLayout/types/searchTypes.ts
@@ -6,10 +6,13 @@ export interface QueryParamTypes {
   tags: string[];
 }
 
+export interface HomeQueryParamTypes {
+  keyword: string;
+  tags: string[];
+}
+
 export interface SearchParamTypes {
   serverId: number;
   type: string;
   queryParam: QueryParamTypes;
 }
-
-

--- a/src/components/ServerHeader/apis/server.ts
+++ b/src/components/ServerHeader/apis/server.ts
@@ -21,11 +21,26 @@ export const fetchMyServers = async (): Promise<ServerResponseTypes> => {
   }
 };
 
-export const fetchServerHome = async (serverId: number) => {
+export const fetchServerHome = async (serverId: number, queryParam?: { keyword: string; tags: string[] }) => {
+  const { keyword, tags } = queryParam || {};
+
+  const queryParams = new URLSearchParams();
+
+  if (keyword) queryParams.append("keyword", keyword);
+  if (tags && tags.length > 0) {
+    for (const tag of tags) {
+      queryParams.append("tags", tag);
+    }
+  }
+
   try {
-    const response = await tokenInstance(`api/v1/servers/${serverId}`).json<HomeResponseTypes>();
+    const response: HomeResponseTypes = await tokenInstance
+      .get(`api/v1/servers/${serverId}?${queryParams.toString()}`)
+      .json();
+
     return response.result;
   } catch (error) {
     console.error(`홈 정보 받아오기 실패 (${serverId}번 서버):`, error);
+    throw error;
   }
 };

--- a/src/constants/noData.ts
+++ b/src/constants/noData.ts
@@ -10,6 +10,11 @@ export const NO_DATA = [
     desc: "지금 커피챗을 개설해보세요!",
   },
   {
+    id: "NO_GLOBAL_CHAT",
+    title: "현재 채팅이 없습니다",
+    desc: "먼저 채팅을 시작해보세요!",
+  },
+  {
     id: "NO_CAREER",
     title: "추가된 경력이 없습니다.",
     desc: "경력을 추가해보세요!",

--- a/src/pages/CoffeeChatListPage/CoffeeChatListPage.tsx
+++ b/src/pages/CoffeeChatListPage/CoffeeChatListPage.tsx
@@ -1,4 +1,5 @@
 import { AddButton, SearchLayout, TitleContainer } from "@/components";
+import { useHashtagSearch } from "@/components/SearchLayout/hooks/useHashtagSearch";
 import { useSearch } from "@/components/SearchLayout/hooks/useSearch";
 import type { QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
 import { MEETING_SORTING_OPTIONS } from "@/constants/dropdown";
@@ -15,14 +16,15 @@ const CoffeeChatListPage = () => {
   const serverId = Number(param);
 
   const location = useLocation();
-  const hashTagData = location.state?.hashTagData || [];
+  const prevKeyword = location.state?.keyword || "";
+  const prevTags = location.state?.tags || [];
 
   const [queryParam, setQueryParam] = useState<QueryParamTypes>({
     page: 0,
     sort: MEETING_SORTING_OPTIONS[0].id,
     scope: "",
-    keyword: "",
-    tags: [],
+    keyword: prevKeyword,
+    tags: prevTags,
   });
 
   const { data } = useSearch({
@@ -31,11 +33,17 @@ const CoffeeChatListPage = () => {
     queryParam,
   });
 
+  const { data: hashtagData = [] } = useHashtagSearch({
+    serverId,
+    keyword: queryParam.keyword,
+    tags: queryParam.tags,
+  });
+
   return (
     <div css={s.layoutStyle}>
       <AddCoffeeChatModal isVisible={isModalVisible} setIsVisible={setIsModalVisible} />
       <AddButton setIsModalVisible={setIsModalVisible} />
-      <SearchLayout queryParam={queryParam} setQueryParam={setQueryParam} hashTagData={hashTagData} />
+      <SearchLayout queryParam={queryParam} setQueryParam={setQueryParam} hashTagData={hashtagData} />
       <TitleContainer
         title="오프라인 커피챗"
         sortingOptions={MEETING_SORTING_OPTIONS}

--- a/src/pages/CoffeeChatListPage/components/CoffeeChatList/CoffeeChatList.styles.ts
+++ b/src/pages/CoffeeChatListPage/components/CoffeeChatList/CoffeeChatList.styles.ts
@@ -9,7 +9,7 @@ export const listContainerStyle = (itemsCount = 0) => css`
 
   box-sizing: content-box;
 
-  border-radius: 2.5rem;
+  border-radius: 1rem;
 
   background: ${theme.color.dark3};
 

--- a/src/pages/GroupChatListPage/GroupChatListPage.tsx
+++ b/src/pages/GroupChatListPage/GroupChatListPage.tsx
@@ -1,4 +1,5 @@
 import { AddButton, SearchLayout, TitleContainer } from "@/components";
+import { useHashtagSearch } from "@/components/SearchLayout/hooks/useHashtagSearch";
 import { useSearch } from "@/components/SearchLayout/hooks/useSearch";
 import type { QueryParamTypes } from "@/components/SearchLayout/types/searchTypes";
 import { GROUP_SORTING_OPTIONS } from "@/constants/dropdown";
@@ -15,14 +16,15 @@ const GroupChatListPage = () => {
   const serverId = Number(param);
 
   const location = useLocation();
-  const hashTagData = location.state?.hashTagData || [];
+  const prevKeyword = location.state?.keyword || "";
+  const prevTags = location.state?.tags || [];
 
   const [queryParam, setQueryParam] = useState<QueryParamTypes>({
     page: 0,
     sort: GROUP_SORTING_OPTIONS[0].id,
     scope: "",
-    keyword: "",
-    tags: [],
+    keyword: prevKeyword,
+    tags: prevTags,
   });
 
   const { data } = useSearch({
@@ -31,11 +33,17 @@ const GroupChatListPage = () => {
     queryParam,
   });
 
+  const { data: hashtagData = [] } = useHashtagSearch({
+    serverId,
+    keyword: queryParam.keyword,
+    tags: queryParam.tags,
+  });
+
   return (
     <div css={s.layoutStyle}>
       <AddGroupChatModal isVisible={isVisible} setIsVisible={setIsVisible} />
       <AddButton setIsModalVisible={setIsVisible} />
-      <SearchLayout queryParam={queryParam} setQueryParam={setQueryParam} hashTagData={hashTagData} />
+      <SearchLayout queryParam={queryParam} setQueryParam={setQueryParam} hashTagData={hashtagData} />
 
       <TitleContainer
         title="그룹 채팅방"

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,10 +1,9 @@
 import { DetailModal, SearchLayout, TitleContainer } from "@/components";
-import { INITIAL_QUERY_PARAM } from "@/components/SearchLayout/constants/searchInitial";
+import { HOME_QUERY_PARAM } from "@/components/SearchLayout/constants/searchInitial";
 import CoffeeChatList from "@/pages/CoffeeChatListPage/components/CoffeeChatList/CoffeeChatList";
 import GroupChatList from "@/pages/GroupChatListPage/components/GroupChatList/GroupChatList";
 import GlobalChatPreview from "@/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview";
 import { useHomeData } from "@/pages/HomePage/hooks/useHomeData";
-import { useHomeSearch } from "@/pages/HomePage/hooks/useHomeSearch";
 import type { SelectedItemTypes } from "@/pages/HomePage/types/selectedItemTypes";
 import { getSelectedChat } from "@/pages/HomePage/utils/getSelectedChat";
 import { useState } from "react";
@@ -17,19 +16,16 @@ const HomePage = () => {
   const param = useParams();
   const serverId = Number(param.serverId);
 
-  const { data: homeData, isLoading } = useHomeData(serverId);
+  const [homeQueryParam, setHomeQueryParam] = useState(HOME_QUERY_PARAM);
 
-  const [queryParam, setQueryParam] = useState(INITIAL_QUERY_PARAM);
+  const { data, isSearching } = useHomeData(serverId, homeQueryParam);
+  const { homeGroupRooms = [], homeMeetingRooms = [], hashTagList = [], notice = null, chat = null } = data || {};
+
   const [selectedItem, setSelectedItem] = useState<SelectedItemTypes>({ id: null, type: null });
-
-  const { homeGroupRooms, homeMeetingRooms, isSearching } = useHomeSearch(serverId, queryParam, 500);
 
   const selectedChat = getSelectedChat(selectedItem, homeGroupRooms, homeMeetingRooms);
 
-  if (isLoading) return <div>로딩 중...</div>;
-  if (!homeData) return <div>데이터 없음</div>;
-
-  const { hashTagList, notice, chat } = homeData;
+  if (!homeGroupRooms && !homeMeetingRooms) return <div>데이터 없음</div>;
 
   const handleItemClick = (type: string, id: string) => {
     setSelectedItem({ type: type, id: id });
@@ -48,7 +44,7 @@ const HomePage = () => {
 
       <div css={s.layoutStyle}>
         <div css={s.leftLayoutStyle(isSearching)}>
-          <SearchLayout queryParam={queryParam} setQueryParam={setQueryParam} hashTagData={hashTagList} />
+          <SearchLayout queryParam={homeQueryParam} setQueryParam={setHomeQueryParam} hashTagData={hashTagList} />
           <TitleContainer
             title="그룹 채팅방"
             textButton="전체보기"

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -17,6 +17,7 @@ const HomePage = () => {
   const serverId = Number(param.serverId);
 
   const [homeQueryParam, setHomeQueryParam] = useState(HOME_QUERY_PARAM);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
   const { data, isSearching } = useHomeData(serverId, homeQueryParam);
   const { homeGroupRooms = [], homeMeetingRooms = [], hashTagList = [], notice = null, chat = null } = data || {};
@@ -75,7 +76,7 @@ const HomePage = () => {
             handleTextButtonClick={() => {
               navigate("../global-chat");
             }}
-            css={{ paddingTop: "10rem" }}
+            css={{ paddingTop: "13rem" }}
           >
             <GlobalChatPreview chat={chat} notice={notice} />
           </TitleContainer>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -17,7 +17,6 @@ const HomePage = () => {
   const serverId = Number(param.serverId);
 
   const [homeQueryParam, setHomeQueryParam] = useState(HOME_QUERY_PARAM);
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
   const { data, isSearching } = useHomeData(serverId, homeQueryParam);
   const { homeGroupRooms = [], homeMeetingRooms = [], hashTagList = [], notice = null, chat = null } = data || {};
@@ -50,7 +49,7 @@ const HomePage = () => {
             title="그룹 채팅방"
             textButton="전체보기"
             handleTextButtonClick={() => {
-              navigate("./group-chat-list", { state: { hashTagData: hashTagList } });
+              navigate("./group-chat-list", { state: { keyword: homeQueryParam.keyword, tags: homeQueryParam.tags } });
             }}
           >
             <GroupChatList data={homeGroupRooms} handleItemClick={handleItemClick} />
@@ -59,7 +58,7 @@ const HomePage = () => {
             title="오프라인 커피챗"
             textButton="전체보기"
             handleTextButtonClick={() => {
-              navigate("./tea-time-list", { state: { hashTagData: hashTagList } });
+              navigate("./tea-time-list", { state: { keyword: homeQueryParam.keyword, tags: homeQueryParam.tags } });
             }}
             css={{ paddingBottom: "5rem" }}
           >

--- a/src/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview.tsx
+++ b/src/pages/HomePage/components/GlobalChatPreview/GlobalChatPreview.tsx
@@ -1,5 +1,5 @@
 import { PinIcon } from "@/assets/svg";
-import { Button } from "@/components";
+import { Button, NoDataContainer } from "@/components";
 import { SINGLE_LINE_NOTICE_DEFAULT } from "@/pages/HomePage/constants/noticeDummy";
 import type { HomeDataTypes } from "@/pages/HomePage/types/homeDataTypes";
 import * as s from "./GlobalChatPreview.styles";
@@ -18,16 +18,18 @@ const GlobalChatPreview = ({ notice, chat }: GlobalChatPreviewProps) => {
         <p>{notice?.pageInfo.totalElements ? notice.noticeList[0].title : SINGLE_LINE_NOTICE_DEFAULT}</p>
       </div>
       <div css={s.chatStyle}>
-        {chat?.chatList.slice(0, 6).map((chat) => {
-          return (
+        {chat?.chatList && chat.chatList.length > 0 ? (
+          chat.chatList.slice(0, 6).map((chat) => (
             <div css={s.chatBarStyle} key={chat.id}>
               <Button variant="tertiary" size="medium">
                 {chat.user.nickname}
               </Button>
               <p>{chat.content}</p>
             </div>
-          );
-        })}
+          ))
+        ) : (
+          <NoDataContainer id="NO_GLOBAL_CHAT" height=" 24.1rem" padding="1rem" />
+        )}
       </div>
     </div>
   );

--- a/src/pages/HomePage/hooks/useHomeData.ts
+++ b/src/pages/HomePage/hooks/useHomeData.ts
@@ -1,14 +1,38 @@
+import useDebounce from "@/components/SearchLayout/hooks/useDebounce";
 import { fetchServerHome } from "@/components/ServerHeader/apis/server";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 
-export const useHomeData = (serverId?: number) => {
-  return useQuery({
-    queryKey: ["serverHome", serverId],
+export const useHomeData = (serverId?: number, queryParam?: { keyword: string; tags: string[] }) => {
+  const debouncedServerId = useDebounce(serverId, 500);
+  const debouncedQueryParam = useDebounce(queryParam, 500);
+
+  const [isSearching, setIsSearching] = useState(false);
+
+  useEffect(() => {
+    setIsSearching((debouncedQueryParam?.keyword ?? "").trim() !== "" || (debouncedQueryParam?.tags?.length ?? 0) > 0);
+  }, [debouncedQueryParam]);
+
+  const queryResult = useQuery({
+    queryKey: ["serverHome", debouncedServerId, debouncedQueryParam],
     queryFn: async () => {
-      if (serverId === undefined) {
+      if (debouncedServerId === undefined) {
         return Promise.reject(new Error("serverId is undefined"));
       }
-      return fetchServerHome(serverId);
+
+      const response = await fetchServerHome(debouncedServerId, debouncedQueryParam);
+
+      const homeGroupRooms = response.groupChatRoom.chatRoomList;
+      const homeMeetingRooms = response.meetingChatRoom.chatRoomList;
+      const hashTagList = response?.hashTagList;
+      const notice = response?.notice;
+      const chat = response?.chat;
+
+      return { homeGroupRooms, homeMeetingRooms, hashTagList, notice, chat };
     },
+    enabled: !!debouncedServerId && !!debouncedQueryParam,
+    placeholderData: keepPreviousData,
   });
+
+  return { ...queryResult, isSearching };
 };


### PR DESCRIPTION
## 🎯 관련 이슈

close #129 

<br />

## 🚀 작업 내용
- 기존 useSearch로 홈 검색 구현했던 부분 삭제하고 홈 정보 조회 수정된 스펙으로 다시 수정(홈 정보 조회 api에서 검색 가능하도록 수정됨)
- 선택한 해시태그는 맨 앞에 오도록.
- 홈에서 사용한 keword와 tags 쿼리 파라미터 그룹챗/커피챗 리스트 페이지에 state로 전달하여 쿼리값 유지

<br />


## 📸 스크린샷

https://github.com/user-attachments/assets/af61d924-fea7-4d7d-bc85-6a6731f8aa1a

<br />





 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->


## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?
- 홈에서 검색했을 때와 채팅방 리스트에서 검색했을 때, param 스펙에 차이가 있어 props 타입을 제네릭으로 설정했습니다!
<br />

