### PR TITLE
#153 [FIX] 검색할 때 홈 UI 깨지는 거 수정

### DIFF
--- a/src/pages/HomePage/HomePage.styles.ts
+++ b/src/pages/HomePage/HomePage.styles.ts
@@ -21,12 +21,11 @@ export const leftLayoutStyle = (isSearching: boolean) => css`
 
   gap: 4rem;
 
-  width: ${isSearching ? "" : "100%"};
-  min-width: ${isSearching ? "76.8rem" : "50rem"};
+  width: 100%;
   z-index: 1;
 `;
 
 export const emptyBoxStyle = css`
-  width: 100%;
-  min-width: 28rem;
+  width: 28rem;
+  flex-shrink: 0;
 `;

--- a/src/routers/Router.tsx
+++ b/src/routers/Router.tsx
@@ -13,6 +13,7 @@ import CareerEdit from "@/pages/UserSettingPage/components/CareerEdit/CareerEdit
 import CareerSettingList from "@/pages/UserSettingPage/components/CareerSettingList/CareerSettingList";
 import LinkedInVerify from "@/pages/UserSettingPage/components/LinkedInVerify/LinkedInVerify";
 import ProfileEdit from "@/pages/UserSettingPage/components/ProfileEdit/ProfileEdit";
+import { Suspense } from "react";
 import { Outlet, createBrowserRouter } from "react-router-dom";
 
 export const Layout = () => {


### PR DESCRIPTION
## 🎯 관련 이슈

close #153

<br />

## 🚀 작업 내용

Before
- 키워드를 입력했을 때
- 오른쪽 전체채팅이 차지하던 공간이 줄면서 UI가 깨졌음

After
- 키워드가 있을 때도
- 오른쪽 공간이 전체 채팅이 있을 때와 같은 너비를 차지하도록 맞춰서
- UI 깨지는 오류 해결

<br />


## 📸 스크린샷

https://github.com/user-attachments/assets/620b87a6-3160-4e93-bdef-c4bdc5bc3ffa


<br />


<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
