### PR TITLE
#157 [FIX] tokenInstance의 토큰을 함수 호출시 가져옴

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -2,6 +2,8 @@ import { beforeRetry } from "@/apis/interceptor";
 import { RETRY_COUNT } from "@/pages/OnboardingPage/constants";
 import ky from "ky";
 
+const accessToken = localStorage.getItem("accessToken");
+
 export const instance = ky.create({
   prefixUrl: import.meta.env.VITE_BASE_URL,
   headers: {
@@ -12,8 +14,6 @@ export const instance = ky.create({
   },
 });
 
-const accessToken = localStorage.getItem("accessToken");
-
 export const tokenInstance = ky.create({
   prefixUrl: import.meta.env.VITE_BASE_URL,
   headers: {
@@ -22,8 +22,10 @@ export const tokenInstance = ky.create({
   hooks: {
     beforeRequest: [
       (request) => {
-        if (accessToken) {
-          request.headers.set("Authorization", `Bearer ${accessToken}`);
+        const token = localStorage.getItem("accessToken");
+        
+        if (token) {
+          request.headers.set("Authorization", `Bearer ${token}`);
         }
       },
     ],

--- a/src/pages/OnboardingPage/hooks/useRedirectToServer.ts
+++ b/src/pages/OnboardingPage/hooks/useRedirectToServer.ts
@@ -10,7 +10,9 @@ export const useRedirectToServer = () => {
     try {
       const myServers = await fetchMyServers();
 
-      if (myServers?.result.count > 0) {
+      if (!myServers) return;
+
+      if (myServers.result.count > 0) {
         const firstServerId = myServers.result.serverList[0].id;
         navigate(PATH.HOME.replace(":serverId", String(firstServerId)));
       } else {


### PR DESCRIPTION
## 🎯 관련 이슈

close #157 

<br />

## 🚀 작업 내용

- 소셜 로그인 리다이렉트 이슈 해결

<br />


## 📸 스크린샷

https://github.com/user-attachments/assets/5f1e4591-d981-41b1-9205-e34ec7faea11


<br />



## 🔎 발견된 장애가 있었나요?

소셜 로그인 후 유저가 속한 서버 ID를 불러오는 과정에서, accessToken이 아직 저장되지 않은 상태에서 API 요청이 먼저 발생해 `401 Unauthorized` 응답을 받는 문제가 있었습니다. 이로 인해 이미 회원가입이 완료된 유저임에도 불구하고 회원가입 페이지로 리다이렉트되는 현상이 발생했습니다.

<br />

 

## 💡 어떻게 해결했나요?

기존 코드는 tokenInstance 내부의 accessToken을 함수 바깥에서 상수로 선언하고 있어, 최초 렌더 시의 토큰 값만 반영되고 이후 값 변경은 반영되지 않는 문제가 있었습니다.
이로 인해 실제로는 토큰이 존재함에도 API 요청 시에는 토큰이 없는 것으로 인식되어 인증 실패가 발생했습니다.

이 문제를 해결하기 위해, beforeRequest 훅 안에서 localStorage.getItem("accessToken")을 호출하도록 수정하여 요청 시점의 최신 토큰 값을 참조하도록 변경했습니다.

<br />



## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

현재 로컬에서는 카카오 로그인이 안되는데 배포 버전에서는 동작해서 
해당 pr에 대해 테스트 하려면 구글로그인으로 테스트 해보심 됩니당 !

<br />
