### PR TITLE
#162 [FIX] 서버 사이드 메뉴 하단 여백 제거

### DIFF
--- a/src/components/ServerHeader/components/ServerDropdown/ServerDropdown.styles.ts
+++ b/src/components/ServerHeader/components/ServerDropdown/ServerDropdown.styles.ts
@@ -68,10 +68,10 @@ export const listStyle = css`
 
   gap: 0.8rem;
 
-  padding: 0.8rem 0.8rem 0;
+  padding: 0.8rem 0.8rem 0.4rem;
 
   width: 100%;
-  height: 31rem;
+  max-height: 31rem;
 
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
## 🎯 관련 이슈

close #162 

<br />

## 🚀 작업 내용

- 서버 사이드 메뉴 하단 여백 제거
  - `width `-> `max-width` 속성으로 변경 

<br />


## 📸 스크린샷
<img width="1512" alt="높이가 변하도록" src="https://github.com/user-attachments/assets/7fb5ae3d-c442-4f10-af13-60289d2dca5e" />

<br />


<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
